### PR TITLE
Add -Wall to compile flags.

### DIFF
--- a/robot_controllers/CMakeLists.txt
+++ b/robot_controllers/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robot_controllers)
 
+if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+endif()
+
 find_package(orocos_kdl REQUIRED)
 find_package(Boost REQUIRED system)
 find_package(catkin REQUIRED

--- a/robot_controllers/include/robot_controllers/trajectory_spline_sampler.h
+++ b/robot_controllers/include/robot_controllers/trajectory_spline_sampler.h
@@ -222,7 +222,7 @@ public:
     }
 
     // Check for number of joints
-    int num_joints = trajectory.points[0].q.size();
+    size_t num_joints = trajectory.points[0].q.size();
 
     // Trajectory length one is special
     if (trajectory.size() == 1)
@@ -316,7 +316,7 @@ public:
   virtual TrajectoryPoint sample(double time)
   {
     // Which segment to sample from.
-    while ((seg_ + 1 < segments_.size()) &&
+    while ((seg_ + 1 < int(segments_.size())) &&
            (segments_[seg_ + 1].start_time < time))
     {
       ++seg_;

--- a/robot_controllers/src/follow_joint_trajectory.cpp
+++ b/robot_controllers/src/follow_joint_trajectory.cpp
@@ -217,7 +217,7 @@ void FollowJointTrajectoryController::update(const ros::Time& now, const ros::Du
       }
 
       // Fill in actual
-      for (int j = 0; j < joints_.size(); ++j)
+      for (size_t j = 0; j < joints_.size(); ++j)
       {
         feedback_.actual.positions[j] = joints_[j]->getPosition();
         feedback_.actual.velocities[j] = joints_[j]->getVelocity();
@@ -225,7 +225,7 @@ void FollowJointTrajectoryController::update(const ros::Time& now, const ros::Du
       }
 
       // Fill in error
-      for (int j = 0; j < joints_.size(); ++j)
+      for (size_t j = 0; j < joints_.size(); ++j)
       {
         feedback_.error.positions[j] = shortest_angular_distance(feedback_.desired.positions[j],
                                                                  feedback_.actual.positions[j]);

--- a/robot_controllers/src/pid.cpp
+++ b/robot_controllers/src/pid.cpp
@@ -155,7 +155,7 @@ double PID::update(double error, double dt)
   }
   else
   {
-    double error_dot = (error-error_last_)/dt;
+    error_dot = (error-error_last_)/dt;
   }
   return update(error, error_dot, dt);
   error_last_ = error;


### PR DESCRIPTION
Fix compile warnings, mostly signed/versus unsigned, but there is one unused variable (error_dot) that is actual bug.
