### PR TITLE
Allow velocity limiting code be reused for forward simulation

### DIFF
--- a/robot_controllers/CMakeLists.txt
+++ b/robot_controllers/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
 project(robot_controllers)
 
 if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-unused-parameter")
 endif()
 
 find_package(orocos_kdl REQUIRED)
-find_package(Boost REQUIRED system)
+find_package(Boost REQUIRED python system)
+find_package(PythonLibs REQUIRED)
 find_package(catkin REQUIRED
   COMPONENTS
     actionlib
@@ -25,6 +26,8 @@ find_package(catkin REQUIRED
     trajectory_msgs
     urdf
 )
+
+catkin_python_setup()
 
 catkin_package(
   INCLUDE_DIRS
@@ -47,8 +50,10 @@ catkin_package(
   DEPENDS
     Boost
     orocos_kdl
+    Python
   LIBRARIES
     robot_controllers
+    robot_controllers_python
 )
 
 include_directories(
@@ -56,6 +61,7 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   ${orocos_kdl_INCLUDE_DIRS}
+  ${PYTHON_INCLUDE_PATH}
 )
 
 # this is a hack, will eventually be unneeded once orocos-kdl is fixed
@@ -66,6 +72,7 @@ add_library(robot_controllers
   src/cartesian_twist.cpp
   src/cartesian_wrench.cpp
   src/diff_drive_base.cpp
+  src/diff_drive_limiter.cpp
   src/follow_joint_trajectory.cpp
   src/gravity_compensation.cpp
   src/parallel_gripper.cpp
@@ -78,6 +85,25 @@ target_link_libraries(robot_controllers
   ${orocos_kdl_LIBRARIES}
 )
 
+add_library(robot_controllers_python
+  src/robot_controllers_python.cpp
+)
+target_link_libraries(robot_controllers_python
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES}
+  ${PYTHON_LIBRARIES}
+  robot_controllers
+)
+set_target_properties(robot_controllers_python
+  PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION}/robot_controllers/
+  PREFIX ""
+)
+if(APPLE)
+  set_target_properties(robot_controllers_python PROPERTIES SUFFIX ".so")
+endif()
+
+
 if (CATKIN_ENABLE_TESTING)
   add_subdirectory(test)
 endif()
@@ -88,6 +114,13 @@ install(FILES robot_controllers.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(TARGETS robot_controllers LIBRARY
-  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+install(
+  TARGETS robot_controllers
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(
+  TARGETS robot_controllers_python
+  LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION}
 )

--- a/robot_controllers/include/robot_controllers/diff_drive_limiter.h
+++ b/robot_controllers/include/robot_controllers/diff_drive_limiter.h
@@ -1,0 +1,137 @@
+/*********************************************************************
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014-2016, Fetch Robotics Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Unbounded Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+// Author: Derek King
+
+#ifndef ROBOT_CONTROLLERS_DIFF_DRIVE_LIMITER_H
+#define ROBOT_CONTROLLERS_DIFF_DRIVE_LIMITER_H
+
+#include <robot_controllers_msgs/DiffDriveLimiterParams.h>
+
+namespace robot_controllers
+{
+
+class DiffDriveLimiter
+{
+ public:
+  /**
+   * @brief Default constructor variables will be set to class has not limits
+   */
+  DiffDriveLimiter();
+
+  /**
+   * @brief Constructor
+   */
+  DiffDriveLimiter(const robot_controllers_msgs::DiffDriveLimiterParams &params);
+
+  /**
+   * @brief Enforces acceleration and velocity limits on desired angular and
+   *     linear velocities, in such a way the that the original desired trajectory
+   *     is maintained.
+   * @param limited_linear_velocity where limited angular velocity will be stored
+   * @param limited_angular_velocity where limited angular velocity will be stored
+   * @param desired_linear_velocity desired linear velocity
+   * @param desired_angular_velocity desired angular velocity
+   * @param last_linear_velocity last linear velocity, used to compute acceleration
+   * @param last_angular_velocity last angular velocity,  used to compute acceleration
+   * @param safety_scaling value between 0.0 and 1.0 used scale back max linear velocity
+   *        for example if safety_scaling was 0.5, then effective max_linear_velocity
+   *        would be half of what the parameter specified
+   * @param dt time delta between now and previous time. used for computing acceleration
+   *
+   * Note: For this to work properly, none of the values should be NaN, and dt > 0.0
+   */
+  void limit(double *limited_linear_velocity,
+             double *limited_angular_velocity,
+             double desired_linear_velocity,
+             double desired_angular_velocity,
+             double last_linear_velocity,
+             double last_angular_velocity,
+             double safety_scaling,
+             double dt);
+
+  /**
+   * @brief Calculates linear and angular velocites from wheel velocities
+   * @param left_velocity where left wheel velocity will be stored
+   * @param right_velocity where right wheel velocity will be stored
+   * @param linear_velocity desired linear velocity
+   * @param angular_velocity desired angular velocity
+   */
+  inline void calcWheelVelocities(double *left_velocity,
+                                  double *right_velocity,
+                                  double linear_velocity,
+                                  double angular_velocity) const
+  {
+    *left_velocity  = linear_velocity - (0.5 * angular_velocity * params_.track_width);
+    *right_velocity = linear_velocity + (0.5 * angular_velocity * params_.track_width);
+  }
+
+  /**
+   * @brief Gets track_width (distance between wheels)
+   */
+  inline double getTrackWidth() const
+  {
+    return params_.track_width;
+  }
+
+  /**
+   * @brief Sets new parameters for diff drive base
+   */
+  void setParams(const robot_controllers_msgs::DiffDriveLimiterParams &new_params);
+
+  /**
+   * @brief Get parameter from diff drive base
+   */
+  inline robot_controllers_msgs::DiffDriveLimiterParams getParams() const
+  {
+    return params_;
+  }
+
+  /**
+   * @brief Get default parameters
+   */
+  static robot_controllers_msgs::DiffDriveLimiterParams getDefaultParams();
+
+  /**
+   * @brief Validate diff drive base parameters, throws exception if they don't make sense
+   */
+  static void validateParams(const robot_controllers_msgs::DiffDriveLimiterParams &params);
+
+ protected:
+  robot_controllers_msgs::DiffDriveLimiterParams params_;
+};
+
+} // namespace robot_controllers
+
+#endif // ROBOT_CONTROLLERS_DIFF_DRIVE_LIMITER_H

--- a/robot_controllers/setup.py
+++ b/robot_controllers/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=["robot_controllers"],
+    package_dir={'': 'src'},
+    )
+
+setup(**d)

--- a/robot_controllers/src/diff_drive_base.cpp
+++ b/robot_controllers/src/diff_drive_base.cpp
@@ -89,8 +89,6 @@ int DiffDriveBaseController::init(ros::NodeHandle& nh, ControllerManager* manage
   right_last_position_ = right_->getPosition();
   last_update_ = ros::Time::now();
 
-  // Get base parameters
-  nh.param<double>("track_width", track_width_, 0.37476);
   nh.param<double>("radians_per_meter", radians_per_meter_, 16.5289);
 
   // If using an external correction (such as robot_pose_ekf or graft)
@@ -112,11 +110,67 @@ int DiffDriveBaseController::init(ros::NodeHandle& nh, ControllerManager* manage
   nh.param<double>("timeout", t, 0.25);
   timeout_ = ros::Duration(t);
 
-  // Get limits of base controller
-  nh.param<double>("max_velocity_x", max_velocity_x_, 1.0);
-  nh.param<double>("max_velocity_r", max_velocity_r_, 4.5);
-  nh.param<double>("max_acceleration_x", max_acceleration_x_, 0.75);
-  nh.param<double>("max_acceleration_r", max_acceleration_r_, 3.0);
+  // Get diff drive parameters
+  robot_controllers_msgs::DiffDriveLimiterParams params = DiffDriveLimiter::getDefaultParams();
+  nh.getParam("track_width", params.track_width);
+  nh.getParam("max_velocity_x", params.max_linear_velocity);
+  nh.getParam("max_velocity_r", params.max_angular_velocity);
+  nh.getParam("max_acceleration_x", params.max_linear_acceleration);
+  nh.getParam("max_acceleration_r", params.max_angular_acceleration);
+
+  bool angular_velocity_limits_linear_velocity = params.angular_velocity_limits_linear_velocity;
+  nh.getParam("angular_velocity_limits_linear_velocity", angular_velocity_limits_linear_velocity);
+  params.angular_velocity_limits_linear_velocity = angular_velocity_limits_linear_velocity;
+
+  bool scale_to_wheel_velocity_limits = params.scale_to_wheel_velocity_limits;
+  nh.getParam("scale_to_wheel_velocity_limits", scale_to_wheel_velocity_limits);
+  params.scale_to_wheel_velocity_limits = scale_to_wheel_velocity_limits;
+
+  // Max wheel velocity parameter is imposted by joint, but limiter needs to
+  // know about it to properly maintain path curvature when turning while driving fast
+  if (left_->getVelocityMax() != right_->getVelocityMax())
+  {
+    ROS_WARN_NAMED("BaseController", "Right and left wheel velocities limits do not match %f %f",
+             left_->getVelocityMax(), right_->getVelocityMax());
+  }
+  // Convert wheel velocity limit in (rad/s) of motor, to linear velocity of wheel
+  double joint_max_wheel_velocity =
+    std::min(left_->getVelocityMax(), right_->getVelocityMax()) / radians_per_meter_;
+
+  // Allow rosparam to limit wheel velocity to lower value than joint
+  double max_wheel_velocity = joint_max_wheel_velocity;
+  if (nh.getParam("max_wheel_velocity", max_wheel_velocity))
+  {
+    if (max_wheel_velocity >= joint_max_wheel_velocity)
+    {
+      ROS_WARN_NAMED("BaseController", "Max wheel velocity param %f is greater than joint limit %f",
+                     max_wheel_velocity, joint_max_wheel_velocity);
+      max_wheel_velocity = joint_max_wheel_velocity;
+    }
+  }
+  params.max_wheel_velocity = max_wheel_velocity;
+
+  try
+  {
+    limiter_.setParams(params);
+  }
+  catch (std::exception &ex)
+  {
+    ROS_ERROR_STREAM_NAMED("BaseController", "Problem with parameters : " << ex.what());
+    initialized_ = false;
+    return -1;
+  }
+
+  // Publisher limiter parameters
+  params_pub_ = nh.advertise<robot_controllers_msgs::DiffDriveLimiterParams>("params", 1, true);
+  params_pub_.publish(limiter_.getParams());
+
+  // Publish cmd values after they have been limited
+  nh.param<bool>("publish_limited_cmd", publish_limited_cmd_, false);
+  if (publish_limited_cmd_)
+  {
+    limited_cmd_pub_ = nh.advertise<geometry_msgs::Twist>("limited_cmd", 10);
+  }
 
   // Subscribe to base commands
   cmd_sub_ = nh.subscribe<geometry_msgs::Twist>("command", 1,
@@ -227,51 +281,31 @@ void DiffDriveBaseController::update(const ros::Time& now, const ros::Duration& 
     desired_x_ = desired_r_ = 0.0;
   }
 
-  // Make sure laser has not timed out
-  if ((safety_scaling_distance_ > 0.0) &&
-      (ros::Time::now() - last_laser_scan_ > ros::Duration(0.5)))
-  {
-    safety_scaling_ = 0.1;
-  }
-
-  // Do velocity acceleration/limiting
-  double x, r;
+  // Lock while copying desired velocities and safety scaling
+  double desired_x, desired_r, safety_scaling;
+  ros::Time last_laser_scan;
   {
     boost::mutex::scoped_lock lock(command_mutex_);
-    // Limit linear velocity based on obstacles
-    x = std::max(-max_velocity_x_ * safety_scaling_, std::min(desired_x_, max_velocity_x_ * safety_scaling_));
-    // Compute how much we actually scaled the linear velocity
-    double actual_scaling = 1.0;
-    if (desired_x_ != 0.0)
-      actual_scaling = x/desired_x_;
-    // Limit angular velocity
-    // Scale same amount as linear velocity so that robot still follows the same "curvature"
-    r = std::max(-max_velocity_r_, std::min(actual_scaling * desired_r_, max_velocity_r_));
+    desired_x = desired_x_;
+    desired_r = desired_r_;
+    safety_scaling = safety_scaling_;
+    last_laser_scan = last_laser_scan_;
   }
-  if (x > last_sent_x_)
+
+  // Make sure laser has not timed out
+  if ((safety_scaling_distance_ > 0.0) &&
+      (ros::Time::now() - last_laser_scan > ros::Duration(0.5)))
   {
-    last_sent_x_ += max_acceleration_x_ * (now - last_update_).toSec();
-    if (last_sent_x_ > x)
-      last_sent_x_ = x;
+    safety_scaling = 0.1;
   }
-  else
-  {
-    last_sent_x_ -= max_acceleration_x_ * (now - last_update_).toSec();
-    if (last_sent_x_ < x)
-      last_sent_x_ = x;
-  }
-  if (r > last_sent_r_)
-  {
-    last_sent_r_ += max_acceleration_r_ * (now - last_update_).toSec();
-    if (last_sent_r_ > r)
-      last_sent_r_ = r;
-  }
-  else
-  {
-    last_sent_r_ -= max_acceleration_r_ * (now - last_update_).toSec();
-    if (last_sent_r_ < r)
-      last_sent_r_ = r;
-  }
+
+  // Perform velocity and acceleration limiting
+  double last_update_dt = (now-last_update_).toSec();
+  double limited_x, limited_r;
+  limiter_.limit(&limited_x, &limited_r,
+                 desired_x, desired_r,
+                 last_sent_x_, last_sent_r_,
+                 safety_scaling, last_update_dt);
 
   double dx = 0.0;
   double dr = 0.0;
@@ -286,8 +320,8 @@ void DiffDriveBaseController::update(const ros::Time& now, const ros::Duration& 
   // Threshold the odometry to avoid noise (especially in simulation)
   if (fabs(left_dx) > wheel_rotating_threshold_ ||
       fabs(right_dx) > wheel_rotating_threshold_ ||
-      last_sent_x_ != 0.0 ||
-      last_sent_r_ != 0.0)
+      limited_x != 0.0 ||
+      limited_r != 0.0)
   {
     // Above threshold, update last position
     left_last_position_ = left_pos;
@@ -300,23 +334,36 @@ void DiffDriveBaseController::update(const ros::Time& now, const ros::Duration& 
     left_vel = right_vel = 0.0;
   }
 
+  double track_width = limiter_.getTrackWidth();
+
   // Calculate forward and angular differences
   double d = (left_dx+right_dx)/2.0;
-  double th = (right_dx-left_dx)/track_width_;
+  double th = (right_dx-left_dx)/track_width;
 
   // Calculate forward and angular velocities
   dx = (left_vel + right_vel)/2.0;
-  dr = (right_vel - left_vel)/track_width_;
+  dr = (right_vel - left_vel)/track_width;
 
   // Actually set command
   if (fabs(dx) > moving_threshold_ ||
       fabs(dr) > rotating_threshold_ ||
-      last_sent_x_ != 0.0 ||
-      last_sent_r_ != 0.0)
+      limited_x != 0.0 ||
+      limited_r != 0.0)
   {
-    setCommand(last_sent_x_ - (last_sent_r_/2.0 * track_width_),
-               last_sent_x_ + (last_sent_r_/2.0 * track_width_));
+    double left_velocity, right_velocity;
+    limiter_.calcWheelVelocities(&left_velocity, &right_velocity,
+                                 limited_x, limited_r);
+    setCommand(left_velocity, right_velocity);
   }
+
+  if (publish_limited_cmd_)
+  {
+    geometry_msgs::Twist limited_cmd;
+    limited_cmd.linear.x = limited_x;
+    limited_cmd.angular.z = limited_r;
+    limited_cmd_pub_.publish(limited_cmd);
+  }
+
 
   // Lock mutex before updating
   boost::mutex::scoped_lock lock(odom_mutex_);
@@ -333,6 +380,8 @@ void DiffDriveBaseController::update(const ros::Time& now, const ros::Duration& 
   odom_.twist.twist.angular.z = dr;
 
   last_update_ = now;
+  last_sent_x_ = limited_x;
+  last_sent_r_ = limited_r;
 }
 
 std::vector<std::string> DiffDriveBaseController::getCommandedNames()

--- a/robot_controllers/src/diff_drive_limiter.cpp
+++ b/robot_controllers/src/diff_drive_limiter.cpp
@@ -1,0 +1,262 @@
+/*********************************************************************
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Fetch Robotics Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Unbounded Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+// Author: Derek King
+
+#include <ros/console.h>
+
+#include <algorithm>
+#include <limits>
+
+#include <robot_controllers/diff_drive_limiter.h>
+
+namespace robot_controllers
+{
+
+
+DiffDriveLimiter::DiffDriveLimiter()
+{
+  setParams(getDefaultParams());
+}
+
+
+DiffDriveLimiter::DiffDriveLimiter(const robot_controllers_msgs::DiffDriveLimiterParams &params)
+{
+  setParams(params);
+}
+
+
+/**
+ * @brief saturates value between +/- limit
+ * @param value value to be limited
+ * @param limit limit to enforce to value
+ * @returns value that can be limited between +/- limit
+ */
+inline double saturate(double value, double limit)
+{
+  return std::max(-limit, std::min(limit, value));
+}
+
+
+/**
+ * @brief determines value needed to scale value between +/- limit
+ * @param value value to be limited
+ * @param limit limit to enforce to value (must be >= 0)
+ * @returns scale that can be multipled by +/- limit to keep it between +/- limit
+ *          abs(value * scale) <= limit
+ */
+inline double scaleToLimit(double value, double limit)
+{
+  if ((value > limit) || (value < -limit))
+  {
+    return std::abs(limit/value);
+  }
+  return 1.0;
+}
+
+
+/**
+ * @brief limits acceleration without dividing by dt
+ * @param desired_velocity desired velocity
+ * @param last_velocity previous velocity value
+ * @param dt time delta since previous cycle
+ * @param max_acceleration acceleration limit
+ * @returns velocity that has been limited so it does not violate
+ *          acceleration limit
+ */
+inline double limitAccel(double desired_velocity, double last_velocity,
+                         double dt, double max_acceleration)
+{
+  // re-arrange equation to avoid dividing by dt
+  // because it could be zero
+  double velocity_delta = desired_velocity - last_velocity;
+  double max_velocity_delta = max_acceleration * dt;
+  return last_velocity + saturate(velocity_delta, max_velocity_delta);
+}
+
+
+void DiffDriveLimiter::limit(double *limited_linear_velocity,
+                                 double *limited_angular_velocity,
+                                 double desired_linear_velocity,
+                                 double desired_angular_velocity,
+                                 double last_linear_velocity,
+                                 double last_angular_velocity,
+                                 double safety_scaling,
+                                 double dt)
+{
+  // Make sure dt is ever negative, and warn if it is 0.0 (since it really shouldn't be)
+  if (dt <= 0.0)
+  {
+    ROS_WARN("DiffDriveLimiter : bad dt=%f", dt);
+    // use dt = 0.0 as special value, with current code it won't cause
+    // issues if it shows up once in a while.
+    // however velocities can't change if dt is always zero
+    dt = 0.0;
+  }
+
+  if (!std::isfinite(desired_linear_velocity) ||
+      !std::isfinite(desired_angular_velocity) )
+  {
+    ROS_ERROR_THROTTLE(1.0, "DiffDriveLimiter : Invalid Range on inputs"
+                       "linear=%f, angular=%f",
+                       desired_linear_velocity, desired_angular_velocity);
+    desired_linear_velocity = 0.0;
+    desired_angular_velocity = 0.0;
+    // Allow acceleration limits to bring robot to a stop
+  }
+
+  if (std::isnan(safety_scaling) ||
+      (safety_scaling < 0.0) ||
+      (safety_scaling > 1.0) )
+  {
+    ROS_ERROR_THROTTLE(1.0, "DiffDriveLimiter : Invalid Range on safety scaling %f",
+                       safety_scaling);
+    if (std::isnan(safety_scaling))
+    {
+      // min/max doesn't always work on NaN, assign to zero
+      safety_scaling = 0.0;
+    }
+    safety_scaling = std::max(0.0, std::min(1.0, safety_scaling));
+  }
+
+  // Use safety scaling to modify max linear velocity
+  double max_linear_velocity = params_.max_linear_velocity * safety_scaling;
+
+  // First limit linear and angular velocities
+  double linear_scale = scaleToLimit(desired_linear_velocity, max_linear_velocity);
+
+  double angular_scale = scaleToLimit(desired_angular_velocity, params_.max_angular_velocity);
+  angular_scale = std::min(angular_scale, linear_scale);
+
+  desired_angular_velocity *= angular_scale;
+
+  if (params_.angular_velocity_limits_linear_velocity)
+  {
+    // Curvature is maintained this by scaling linear and angular velocity by
+    // the same factor
+    desired_linear_velocity *= angular_scale;
+  }
+  else
+  {
+    // Do not scale back linear velocity when angular velocity reaches limit.
+    // This is how the previous code worked, but it does not maintain curvature
+    desired_linear_velocity *= linear_scale;
+  }
+
+  // Calculate right wheel velocity and left wheel velocity from linear velocities
+  double left, right;
+  calcWheelVelocities(&left, &right, desired_linear_velocity, desired_angular_velocity);
+
+  // Limit right and left wheel velocites
+  if (params_.scale_to_wheel_velocity_limits)
+  {
+    // Scale wheel velocities together, to maintain curvature
+    double wheel_velocity = std::max(fabs(left), fabs(right));
+    double wheel_scale = scaleToLimit(wheel_velocity, params_.max_wheel_velocity);
+    left *= wheel_scale;
+    right *= wheel_scale;
+  }
+  else
+  {
+    // Scale wheel velocities separately.
+    // This is how the previous code worked, but it does not maintain curvative
+    left = saturate(left, params_.max_wheel_velocity);
+    right = saturate(right, params_.max_wheel_velocity);
+  }
+
+  // Convert left/right velocities back to angular and linear commands
+  desired_linear_velocity = 0.5*(right+left);
+  desired_angular_velocity = (right-left)/params_.track_width;
+
+  // Limit accelerations, for now don't try to maintain curvature
+  // because it can't always be done if robot is already moving
+  // However, if robot starts from stop and doesn't change commands
+  // having acceleration limit matching would maintain curvature of robot
+  *limited_linear_velocity = limitAccel(desired_linear_velocity, last_linear_velocity,
+                                        dt, params_.max_linear_acceleration);
+  *limited_angular_velocity = limitAccel(desired_angular_velocity, last_angular_velocity,
+                                         dt, params_.max_angular_acceleration);
+}
+
+
+/**
+ * @brief Get default parameters
+ */
+robot_controllers_msgs::DiffDriveLimiterParams DiffDriveLimiter::getDefaultParams()
+{
+  robot_controllers_msgs::DiffDriveLimiterParams params;
+  params.max_linear_velocity = 1.0;
+  params.max_angular_velocity = 4.5;
+  params.max_linear_acceleration = 0.75;
+  params.max_angular_acceleration = 3.0;
+  params.max_wheel_velocity = 1.1;
+  params.track_width = 0.37476;
+  params.angular_velocity_limits_linear_velocity = false;
+  params.scale_to_wheel_velocity_limits = false;
+  return params;
+}
+
+
+/**
+ * @brief Verifies that value is greater than zero (+infinity is ok), NaN is not ok
+ */
+void validatePositive(double value, const char* name)
+{
+  if (std::isnan(value) || (value <= 0.0))
+  {
+    std::stringstream ss;
+    ss << "Invalid value for " << name << " : " << value;
+    throw std::out_of_range(ss.str());
+  }
+}
+
+
+void DiffDriveLimiter::validateParams(const robot_controllers_msgs::DiffDriveLimiterParams &params)
+{
+  validatePositive(params.max_linear_velocity, "max_linear_velocity");
+  validatePositive(params.max_angular_velocity, "max_angular_velocity");
+  validatePositive(params.max_wheel_velocity, "max_wheel_velocity");
+  validatePositive(params.max_linear_acceleration, "max_linear_acceleration");
+  validatePositive(params.max_angular_acceleration, "max_angular_acceleration");
+  validatePositive(params.track_width, "track_width");
+}
+
+
+void DiffDriveLimiter::setParams(const robot_controllers_msgs::DiffDriveLimiterParams &new_params)
+{
+  validateParams(new_params);
+  params_ = new_params;
+}
+
+} // namespace robot_controllers

--- a/robot_controllers/src/robot_controllers/init.py
+++ b/robot_controllers/src/robot_controllers/init.py
@@ -1,0 +1,1 @@
+""" Python wrapper for C++ library functions in robot_controllers """

--- a/robot_controllers/src/robot_controllers_python.cpp
+++ b/robot_controllers/src/robot_controllers_python.cpp
@@ -1,0 +1,109 @@
+/*********************************************************************
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Fetch Robotics Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Unbounded Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+// Author: Derek King
+
+#include <boost/python.hpp>
+#include <robot_controllers/diff_drive_limiter.h>
+#include <robot_controllers/DiffDriveLimiterParams.h>
+
+namespace bp = boost::python;
+namespace rc = robot_controllers;
+
+class pyDiffDriveLimiter : public rc::DiffDriveLimiter
+{
+public:
+  bp::tuple limit(double desired_linear_velocity,
+                  double desired_angular_velocity,
+                  double last_linear_velocity,
+                  double last_angular_velocity,
+                  double safety_scaling,
+                  double dt)
+  {
+    double limited_linear_velocity, limited_angular_velocity;
+    DiffDriveLimiter::limit(&limited_linear_velocity,
+                                &limited_angular_velocity,
+                                desired_linear_velocity,
+                                desired_angular_velocity,
+                                last_linear_velocity,
+                                last_angular_velocity,
+                                safety_scaling,
+                                dt);
+    return bp::make_tuple(limited_linear_velocity, limited_angular_velocity);
+  }
+
+
+  bp::tuple calcWheelVelocities(double linear_velocity,
+                                double angular_velocity)
+  {
+    double left_velocity, right_velocity;
+    DiffDriveLimiter::calcWheelVelocities(&left_velocity,
+                                              &right_velocity,
+                                              linear_velocity,
+                                              angular_velocity);
+    return bp::make_tuple(left_velocity, right_velocity);
+  }
+};
+
+BOOST_PYTHON_MODULE(robot_controllers_python)
+{
+  bp::class_<rc::DiffDriveLimiterParams>("DiffDriveLimiterParams")
+    .def_readwrite("max_linear_velocity", &rc::DiffDriveLimiterParams::max_linear_velocity)
+    .def_readwrite("max_linear_acceleration",
+                   &rc::DiffDriveLimiterParams::max_linear_acceleration)
+    .def_readwrite("max_angular_velocity", &rc::DiffDriveLimiterParams::max_angular_velocity)
+    .def_readwrite("max_angular_acceleration",
+                   &rc::DiffDriveLimiterParams::max_angular_acceleration)
+    .def_readwrite("max_wheel_velocity", &rc::DiffDriveLimiterParams::max_wheel_velocity)
+    .def_readwrite("track_width", &rc::DiffDriveLimiterParams::track_width)
+    .def_readwrite("angular_velocity_limits_linear_velocity",
+                   &rc::DiffDriveLimiterParams::angular_velocity_limits_linear_velocity)
+    .def_readwrite("scale_to_wheel_velocity_limits",
+                   &rc::DiffDriveLimiterParams::scale_to_wheel_velocity_limits)
+    ;
+
+  bp::class_<pyDiffDriveLimiter>("DiffDriveLimiter")
+    .def("limit", &pyDiffDriveLimiter::limit)
+    .def("calcWheelVelocities", &pyDiffDriveLimiter::calcWheelVelocities)
+    .add_property("params",
+                  &pyDiffDriveLimiter::getParams,
+                  &pyDiffDriveLimiter::setParams)
+    .def("setParams", &pyDiffDriveLimiter::setParams)
+    .def("getParams", &pyDiffDriveLimiter::getParams)
+    .def("getDefaultParams", &pyDiffDriveLimiter::getDefaultParams)
+    .staticmethod("getDefaultParams")
+    .def("validateParams", &pyDiffDriveLimiter::validateParams)
+    .staticmethod("validateParams")
+    ;
+}

--- a/robot_controllers/test/CMakeLists.txt
+++ b/robot_controllers/test/CMakeLists.txt
@@ -3,3 +3,7 @@ target_link_libraries(trajectory_tests
   ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}
 )
+
+catkin_add_gtest(diff_drive_limiter_test diff_drive_limiter_test.cpp)
+target_link_libraries(diff_drive_limiter_test robot_controllers)
+

--- a/robot_controllers/test/diff_drive_limiter_test.cpp
+++ b/robot_controllers/test/diff_drive_limiter_test.cpp
@@ -1,0 +1,640 @@
+/*
+ * Copyright (c) 2016, Fetch Robotics Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Fetch Robotics Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL FETCH ROBOTICS INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Author: Derek King
+
+#include <gtest/gtest.h>
+#include <robot_controllers/diff_drive_limiter.h>
+#include <limits>
+
+using robot_controllers::DiffDriveLimiter;
+using robot_controllers::DiffDriveLimiterParams;
+
+TEST(DiffDriveLimiterTests, 1_test_velocity_limits)
+{
+  DiffDriveLimiterParams params;
+  params.max_linear_velocity  = 2.0;
+  params.max_linear_acceleration = std::numeric_limits<double>::max();
+  params.max_angular_velocity = 4.0;
+  params.max_angular_acceleration = std::numeric_limits<double>::max();
+  params.max_wheel_velocity = std::numeric_limits<double>::max();
+  params.track_width = 0.5;
+  params.angular_velocity_limits_linear_velocity = false;
+  params.scale_to_wheel_velocity_limits = false;
+  DiffDriveLimiter limiter(params);
+
+  double limited_linear_velocity, limited_angular_velocity;
+  double desired_linear_velocity, desired_angular_velocity;
+  double safety_scaling = 1.0;
+  double dt = 1.0;
+
+
+  // Make sure linear or angular velocity is not limited when under limits
+  desired_linear_velocity = 1.0;
+  desired_angular_velocity = 1.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+
+  EXPECT_EQ(limited_linear_velocity, desired_linear_velocity);
+  EXPECT_EQ(limited_angular_velocity, desired_angular_velocity);
+
+  // Make sure linear velocity hits positive limit
+  desired_linear_velocity = 10.0;
+  desired_angular_velocity = 0.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity, params.max_linear_velocity, 1e-6);
+
+  // Make sure linear velocity hits negative limit
+  desired_linear_velocity = -10.0;
+  desired_angular_velocity = 0.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity, -params.max_linear_velocity, 1e-6);
+
+
+  // Make sure angular velocity hits positive limit
+  desired_linear_velocity = 0.0;
+  desired_angular_velocity = 10.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_angular_velocity, params.max_angular_velocity, 1e-6);
+
+  // Make sure angular velocity hits negative limit
+  desired_linear_velocity = 0.0;
+  desired_angular_velocity = -10.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_angular_velocity, -params.max_angular_velocity, 1e-6);
+
+
+  // Make sure linear velocity positive limit is reduced by safety scaling
+  desired_linear_velocity = 10.0;
+  desired_angular_velocity = 0.0;
+  safety_scaling = 0.5;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity, params.max_linear_velocity*safety_scaling, 1e-6);
+
+  // Make sure angular velocity hits negative limit
+  desired_linear_velocity = -10.0;
+  desired_angular_velocity = 0.0;
+  safety_scaling = 0.25;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity, -params.max_linear_velocity*safety_scaling, 1e-6);
+
+
+  // Make sure angular velocity positive is not limited by safety scaling when linear velocity is 0
+  desired_linear_velocity = 0.0;
+  desired_angular_velocity = 1.0;
+  safety_scaling = 0.0; // This would force angular velocity to be zero
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_angular_velocity, desired_angular_velocity, 1e-6);
+}
+
+
+TEST(DiffDriveLimiterTests, 2_test_wheel_velocity_limits)
+{
+  DiffDriveLimiterParams params;
+  params.max_linear_velocity = std::numeric_limits<double>::max();;
+  params.max_linear_acceleration = std::numeric_limits<double>::max();
+  params.max_angular_velocity = std::numeric_limits<double>::max();;
+  params.max_angular_acceleration = std::numeric_limits<double>::max();
+  params.max_wheel_velocity = 2.0;
+  params.track_width = 1.0;
+  params.angular_velocity_limits_linear_velocity = false;
+  params.scale_to_wheel_velocity_limits = false;
+  DiffDriveLimiter limiter(params);
+
+  double limited_linear_velocity, limited_angular_velocity;
+  double desired_linear_velocity, desired_angular_velocity;
+  double safety_scaling = 1.0;
+  double dt = 1.0;
+
+  // Make sure linear or angular velocity is not limited when wheel velocity is less than limits
+  desired_linear_velocity = 1.0;
+  desired_angular_velocity = 0.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity, desired_linear_velocity, 1e-6);
+  EXPECT_NEAR(limited_angular_velocity, desired_angular_velocity, 1e-6);
+
+  // Make sure linear or angular velocity is not limited when wheel velocity is less than limits
+  desired_linear_velocity = 0.0;
+  desired_angular_velocity = 1.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity, desired_linear_velocity, 1e-6);
+  EXPECT_NEAR(limited_angular_velocity, desired_angular_velocity, 1e-6);
+
+  // When linear velocity is too large,
+  // Make sure angular velocity stays zero,
+  // and wheel velocites are equal to limits
+  desired_linear_velocity = 10.0;
+  desired_angular_velocity = 0.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  // Angular velocity should stay near zero
+  EXPECT_NEAR(limited_angular_velocity, desired_angular_velocity, 1e-6);
+  // Angular velocity limit is same as wheel velocity limits
+  EXPECT_NEAR(limited_linear_velocity, params.max_wheel_velocity, 1e-6);
+
+  // When linear velocity is too large,
+  // Make sure linear velocity stays zero,
+  // and wheel velocites are equal to limits
+  desired_linear_velocity = 0.0;
+  desired_angular_velocity = 10.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  // linear velocity should stay near zero
+  EXPECT_NEAR(limited_linear_velocity, desired_linear_velocity, 1e-6);
+
+  double left_velocity, right_velocity;
+  limiter.calcWheelVelocities(&left_velocity, &right_velocity,
+                              limited_linear_velocity, limited_angular_velocity);
+  EXPECT_NEAR(left_velocity, -params.max_wheel_velocity, 1e-6);
+  EXPECT_NEAR(right_velocity, params.max_wheel_velocity, 1e-6);
+
+  // When linear velocity is too large,
+  // Make sure linear velocity stays zero,
+  // and wheel velocites are equal to limits
+  desired_linear_velocity = 0.0;
+  desired_angular_velocity = -10.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  // linear velocity should stay near zero
+  EXPECT_NEAR(limited_linear_velocity, desired_linear_velocity, 1e-6);
+
+  limiter.calcWheelVelocities(&left_velocity, &right_velocity,
+                              limited_linear_velocity, limited_angular_velocity);
+  EXPECT_NEAR(left_velocity, params.max_wheel_velocity, 1e-6);
+  EXPECT_NEAR(right_velocity, -params.max_wheel_velocity, 1e-6);
+}
+
+
+
+TEST(DiffDriveLimiterTests, 3_test_curvature_matching)
+{
+  DiffDriveLimiterParams params;
+  params.max_linear_velocity = 2.0;
+  params.max_linear_acceleration = std::numeric_limits<double>::max();
+  params.max_angular_velocity = 4.0;
+  params.max_angular_acceleration = std::numeric_limits<double>::max();;
+  params.max_wheel_velocity = std::numeric_limits<double>::max();
+  params.track_width = 1.0;
+  params.angular_velocity_limits_linear_velocity = false;
+  params.scale_to_wheel_velocity_limits = false;
+  DiffDriveLimiter limiter(params);
+
+  double limited_linear_velocity, limited_angular_velocity;
+  double desired_linear_velocity, desired_angular_velocity;
+  double safety_scaling = 1.0;
+  double dt = 1.0;
+
+  // Make sure curvature matches when linear velocity goes over limit
+  desired_linear_velocity = 3.0;
+  desired_angular_velocity = 3.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  EXPECT_NEAR(limited_linear_velocity, params.max_linear_velocity, 1e-6);
+
+
+  // Make sure curvature matches when linear velocity goes over limit
+  desired_linear_velocity = -3.0;
+  desired_angular_velocity = 3.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  EXPECT_NEAR(limited_linear_velocity, -params.max_linear_velocity, 1e-6);
+
+  // when angular_velocity_limits_linear_velocity flag is not set,
+  // make sure angular limits do not effect linear velocity
+  desired_linear_velocity = 1.0;
+  desired_angular_velocity = 9.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity, desired_linear_velocity, 1e-6);
+
+
+  // when angular_velocity_limits_linear_velocity flag is set,
+  // Make sure curvature matches when angular velocity hits limit
+  params.angular_velocity_limits_linear_velocity = true;
+  limiter.setParams(params);
+  desired_linear_velocity = 1.0;
+  desired_angular_velocity = 9.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  EXPECT_NEAR(limited_angular_velocity, params.max_angular_velocity, 1e-6);
+
+  // Make sure curvature matches when safety scaling is non-zero
+  params.angular_velocity_limits_linear_velocity = true;
+  limiter.setParams(params);
+  desired_linear_velocity = 2.0;
+  desired_angular_velocity = 3.0;
+  safety_scaling = 0.25;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  EXPECT_NEAR(limited_linear_velocity, desired_linear_velocity*safety_scaling, 1e-6);
+  safety_scaling = 1.0;
+
+
+  // when angular_velocity_limits_linear_velocity flag is set,
+  // Make sure curvature matches when angular velocity hits limit
+  params.angular_velocity_limits_linear_velocity = true;
+  limiter.setParams(params);
+  desired_linear_velocity = 1.0;
+  desired_angular_velocity = -9.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  EXPECT_NEAR(limited_angular_velocity, -params.max_angular_velocity, 1e-6);
+}
+
+
+TEST(DiffDriveLimiterTests, 4_test_wheel_curvature_matching)
+{
+  DiffDriveLimiterParams params;
+  params.max_linear_velocity = std::numeric_limits<double>::max();
+  params.max_linear_acceleration = std::numeric_limits<double>::max();
+  params.max_angular_velocity = std::numeric_limits<double>::max();
+  params.max_angular_acceleration = std::numeric_limits<double>::max();;
+  params.max_wheel_velocity = 2.0;
+  params.track_width = 1.0;
+  params.angular_velocity_limits_linear_velocity = false;
+  params.scale_to_wheel_velocity_limits = true;
+  DiffDriveLimiter limiter(params);
+
+  double limited_linear_velocity, limited_angular_velocity;
+  double desired_linear_velocity, desired_angular_velocity;
+  double left_velocity, right_velocity;
+  double safety_scaling = 1.0;
+  double dt = 1.0;
+
+  // Make sure curvature matches when linear velocity goes over limit
+  desired_linear_velocity = 10.0;
+  desired_angular_velocity = 1.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  limiter.calcWheelVelocities(&left_velocity, &right_velocity,
+                              limited_linear_velocity, limited_angular_velocity);
+  EXPECT_LE(left_velocity,  params.max_wheel_velocity+1e-6);
+  EXPECT_LE(right_velocity, params.max_wheel_velocity+1e-6);
+  EXPECT_GE(left_velocity,  -params.max_wheel_velocity-1e-6);
+  EXPECT_GE(right_velocity, -params.max_wheel_velocity-1e-6);
+
+  // Make sure curvature matches when linear velocity goes over negative limit
+  desired_linear_velocity = -10.0;
+  desired_angular_velocity = 1.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  limiter.calcWheelVelocities(&left_velocity, &right_velocity,
+                              limited_linear_velocity, limited_angular_velocity);
+  EXPECT_LE(left_velocity,  params.max_wheel_velocity+1e-6);
+  EXPECT_LE(right_velocity, params.max_wheel_velocity+1e-6);
+  EXPECT_GE(left_velocity,  -params.max_wheel_velocity-1e-6);
+  EXPECT_GE(right_velocity, -params.max_wheel_velocity-1e-6);
+
+
+  // Make sure curvature matches when angular velocity goes over limit
+  desired_linear_velocity = 1.0;
+  desired_angular_velocity = 10.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  limiter.calcWheelVelocities(&left_velocity, &right_velocity,
+                              limited_linear_velocity, limited_angular_velocity);
+  EXPECT_LE(left_velocity,  params.max_wheel_velocity+1e-6);
+  EXPECT_LE(right_velocity, params.max_wheel_velocity+1e-6);
+  EXPECT_GE(left_velocity,  -params.max_wheel_velocity-1e-6);
+  EXPECT_GE(right_velocity, -params.max_wheel_velocity-1e-6);
+
+  // Make sure curvature matches when linear velocity goes over negative limit
+  desired_linear_velocity = 1.0;
+  desired_angular_velocity = -10.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                safety_scaling, dt);
+  EXPECT_NEAR(limited_linear_velocity/limited_angular_velocity,
+              desired_linear_velocity/desired_angular_velocity, 1e-6);
+  limiter.calcWheelVelocities(&left_velocity, &right_velocity,
+                              limited_linear_velocity, limited_angular_velocity);
+  EXPECT_LE(left_velocity,  params.max_wheel_velocity+1e-6);
+  EXPECT_LE(right_velocity, params.max_wheel_velocity+1e-6);
+  EXPECT_GE(left_velocity,  -params.max_wheel_velocity-1e-6);
+  EXPECT_GE(right_velocity, -params.max_wheel_velocity-1e-6);
+}
+
+
+
+TEST(DiffDriveLimiterTests, 5_test_acceleration_limits)
+{
+  DiffDriveLimiterParams params;
+  params.max_linear_velocity = std::numeric_limits<double>::max();
+  params.max_linear_acceleration = 2.0;
+  params.max_angular_velocity = std::numeric_limits<double>::max();
+  params.max_angular_acceleration = 4.0;
+  params.max_wheel_velocity = std::numeric_limits<double>::max();
+  params.track_width = 1.0;
+  params.angular_velocity_limits_linear_velocity = false;
+  params.scale_to_wheel_velocity_limits = false;
+  DiffDriveLimiter limiter(params);
+
+  double limited_linear_velocity, limited_angular_velocity;
+  double desired_linear_velocity, desired_angular_velocity;
+  double last_linear_velocity, last_angular_velocity;
+  double safety_scaling = 1.0;
+  double dt = 0.5;
+  double desired_linear_accel, desired_angular_accel;
+  double actual_linear_accel, actual_angular_accel;
+
+  // Make sure accelerations are not limited when they are below limites
+  desired_linear_accel = 1.0;
+  desired_angular_accel = -1.0;
+  last_linear_velocity = 9.0;
+  last_angular_velocity = -4.0;
+  desired_linear_velocity = desired_linear_accel*dt + last_linear_velocity;
+  desired_angular_velocity = desired_angular_accel*dt + last_angular_velocity;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                last_linear_velocity, last_angular_velocity,
+                safety_scaling, dt);
+  // If acceleration is below limits, then limited veloicty with match desired velocity
+  EXPECT_NEAR(desired_linear_velocity, limited_linear_velocity, 1e-6);
+  EXPECT_NEAR(desired_angular_velocity, limited_angular_velocity, 1e-6);
+
+
+  // Make sure linear acceleration is limited to max
+  desired_linear_accel = 10.0;
+  desired_angular_accel = 1.0;
+  last_linear_velocity = 3.0;
+  last_angular_velocity = -8.0;
+  desired_linear_velocity = desired_linear_accel*dt + last_linear_velocity;
+  desired_angular_velocity = desired_angular_accel*dt + last_angular_velocity;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                last_linear_velocity, last_angular_velocity,
+                safety_scaling, dt);
+  actual_linear_accel = (limited_linear_velocity - last_linear_velocity)/dt;
+  actual_angular_accel = (limited_angular_velocity - last_angular_velocity)/dt;
+  EXPECT_NEAR(actual_linear_accel, params.max_linear_acceleration, 1e-6);
+  EXPECT_NEAR(actual_angular_accel, desired_angular_accel, 1e-6);
+
+  // Make sure linear acceleration is limited to negative max
+  desired_linear_accel = -10.0;
+  desired_angular_accel = 1.0;
+  last_linear_velocity = 0.0;
+  last_angular_velocity = 4.0;
+  desired_linear_velocity = desired_linear_accel*dt + last_linear_velocity;
+  desired_angular_velocity = desired_angular_accel*dt + last_angular_velocity;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                last_linear_velocity, last_angular_velocity,
+                safety_scaling, dt);
+  actual_linear_accel = (limited_linear_velocity - last_linear_velocity)/dt;
+  actual_angular_accel = (limited_angular_velocity - last_angular_velocity)/dt;
+  EXPECT_NEAR(actual_linear_accel, -params.max_linear_acceleration, 1e-6);
+  EXPECT_NEAR(actual_angular_accel, desired_angular_accel, 1e-6);
+
+
+
+  // Make sure angular acceleration is limited to max
+  desired_linear_accel = 1.0;
+  desired_angular_accel = 13.5;
+  last_linear_velocity = 6.0;
+  last_angular_velocity = -51.0;
+  desired_linear_velocity = desired_linear_accel*dt + last_linear_velocity;
+  desired_angular_velocity = desired_angular_accel*dt + last_angular_velocity;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                last_linear_velocity, last_angular_velocity,
+                safety_scaling, dt);
+  actual_linear_accel = (limited_linear_velocity - last_linear_velocity)/dt;
+  actual_angular_accel = (limited_angular_velocity - last_angular_velocity)/dt;
+  EXPECT_NEAR(actual_linear_accel, desired_linear_accel, 1e-6);
+  EXPECT_NEAR(actual_angular_accel, params.max_angular_acceleration, 1e-6);
+
+  // Make sure angular acceleration is limited to negative max
+  desired_linear_accel = -0.5;
+  desired_angular_accel = -15.0;
+  last_linear_velocity = 3.0;
+  last_angular_velocity = -2.0;
+  desired_linear_velocity = desired_linear_accel*dt + last_linear_velocity;
+  desired_angular_velocity = desired_angular_accel*dt + last_angular_velocity;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                last_linear_velocity, last_angular_velocity,
+                safety_scaling, dt);
+  actual_linear_accel = (limited_linear_velocity - last_linear_velocity)/dt;
+  actual_angular_accel = (limited_angular_velocity - last_angular_velocity)/dt;
+  EXPECT_NEAR(actual_linear_accel, desired_linear_accel, 1e-6);
+  EXPECT_NEAR(actual_angular_accel, -params.max_angular_acceleration, 1e-6);
+
+  // Make sure both accelerations are limited between -max and max
+  for (desired_linear_accel = -6.0; desired_linear_accel<6.0; desired_linear_accel+=0.5)
+  {
+    for (desired_angular_accel = -12.0; desired_linear_accel<12.0; desired_linear_accel+=0.5)
+    {
+      last_linear_velocity = 3.0;
+      last_angular_velocity = -2.0;
+      desired_linear_velocity = desired_linear_accel*dt + last_linear_velocity;
+      desired_angular_velocity = desired_angular_accel*dt + last_angular_velocity;
+      limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                    desired_linear_velocity, desired_angular_velocity,
+                    last_linear_velocity, last_angular_velocity,
+                    safety_scaling, dt);
+      actual_linear_accel = (limited_linear_velocity - last_linear_velocity)/dt;
+      actual_angular_accel = (limited_angular_velocity - last_angular_velocity)/dt;
+      // Assert instead of Expect, because loop could create a lot of failing test cases
+      ASSERT_LE(actual_linear_accel,  params.max_linear_acceleration+1e-6);
+      ASSERT_GE(actual_linear_accel, -params.max_linear_acceleration-1e-6);
+      ASSERT_LE(actual_angular_accel,  params.max_angular_acceleration+1e-6);
+      ASSERT_GE(actual_angular_accel, -params.max_angular_acceleration-1e-6);
+    }
+  }
+
+
+  // Make sure acceleration limits still work when dt is zero
+  dt = 0.0;
+  desired_linear_accel = 1.0;
+  desired_angular_accel = -1.0;
+  last_linear_velocity = 9.0;
+  last_angular_velocity = -4.0;
+  desired_linear_velocity = 12.0;
+  desired_angular_velocity = 3.0;
+  limiter.limit(&limited_linear_velocity, &limited_angular_velocity,
+                desired_linear_velocity, desired_angular_velocity,
+                last_linear_velocity, last_angular_velocity,
+                safety_scaling, dt);
+  // If dt is zero, then veloicties can't change
+  EXPECT_NEAR(limited_linear_velocity, last_linear_velocity, 1e-6);
+  EXPECT_NEAR(limited_angular_velocity, last_angular_velocity, 1e-6);
+}
+
+
+TEST(DiffDriveLimiterTests, 6_validate_params)
+{
+  // Make sure default params are ok
+  DiffDriveLimiterParams params;
+
+  params = DiffDriveLimiter::getDefaultParams();
+  EXPECT_NO_THROW(DiffDriveLimiter::validateParams(params));
+
+
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_linear_velocity = 0.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_linear_velocity = NAN;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_linear_velocity = -1.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+
+
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_angular_velocity = 0.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_angular_velocity = NAN;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_angular_velocity = -1.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+
+
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_wheel_velocity = 0.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_wheel_velocity = NAN;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_wheel_velocity = -1.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+
+
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_linear_acceleration = 0.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_linear_acceleration = NAN;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_linear_acceleration = -1.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+
+
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_angular_acceleration = 0.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_angular_acceleration = NAN;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.max_angular_acceleration = -1.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+
+
+  params = DiffDriveLimiter::getDefaultParams();
+  params.track_width = 0.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.track_width = NAN;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+  params = DiffDriveLimiter::getDefaultParams();
+  params.track_width = -1.0;
+  EXPECT_THROW(DiffDriveLimiter::validateParams(params), std::exception);
+}
+
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/robot_controllers_msgs/CMakeLists.txt
+++ b/robot_controllers_msgs/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED
 add_message_files(
   FILES
     ControllerState.msg
+    DiffDriveLimiterParams.msg
 )
 
 add_action_files(

--- a/robot_controllers_msgs/msg/DiffDriveLimiterParams.msg
+++ b/robot_controllers_msgs/msg/DiffDriveLimiterParams.msg
@@ -1,0 +1,28 @@
+# Various parameters for diff driver base velocity and acceleration limiter
+# This message allows limits that would imposed by diff_drive_base
+# to be understood by other components without needing access to 
+# same set of rosparams, or URDF settings
+
+float64 max_linear_velocity
+float64 max_linear_acceleration
+
+float64 max_angular_velocity
+float64 max_angular_acceleration
+
+# Wheel velocity limit are linear velocity (m/s) not angular velocities (rad/s)
+float64 max_wheel_velocity
+
+# distance between two wheels 
+# used for calculating wheel velocities from angular velocity
+float64 track_width
+
+# If true limiter will reduce linear velocity
+# when angular velocity is beyond limit so
+# so path curvature is maintained
+bool angular_velocity_limits_linear_velocity
+
+# If true, linear and angular velocities will 
+# scaled if wheel velocities beyond limits
+# so path curvature is maintained
+# otherwise wheel velocities are limited independently
+bool scale_to_wheel_velocity_limits


### PR DESCRIPTION
- Put limiting code in separate class that can be reused
- New ROS message that allows limiter parameters to be broadcast to anything that might use them
- Have option to maintain curvature when wheel velocity is reached
- Have option to maintain curvature when angular velocity is reached
- Created boost python binding to limiter to allow easy simulation of path effects
- Created simple python script to simulate the path for different input commands
- Gtest cases for limiter
