### PR TITLE
Dynamically load controllers

### DIFF
--- a/robot_controllers_interface/src/controller_loader.cpp
+++ b/robot_controllers_interface/src/controller_loader.cpp
@@ -52,7 +52,7 @@ bool ControllerLoader::init(const std::string& name, ControllerManager* manager)
       controller_ = plugin_loader_.createInstance(controller_type);
       controller_->init(nh, manager);
     }
-    catch(pluginlib::LibraryLoadException e)
+    catch (pluginlib::LibraryLoadException e)
     {
       return false;
     }  

--- a/robot_controllers_interface/src/controller_loader.cpp
+++ b/robot_controllers_interface/src/controller_loader.cpp
@@ -46,11 +46,17 @@ bool ControllerLoader::init(const std::string& name, ControllerManager* manager)
 
   if (nh.getParam("type", controller_type))
   {
-    controller_ = plugin_loader_.createInstance(controller_type);
-    controller_->init(nh, manager);
+    // If plugin is bad, catch pluginlib exception 
+    try
+    {
+      controller_ = plugin_loader_.createInstance(controller_type);
+      controller_->init(nh, manager);
+    }catch( pluginlib::LibraryLoadException e)
+    {
+      return false;
+    }  
     return true;
   }
-
   ROS_ERROR_STREAM("Unable to load controller " << name.c_str());
   return false;
 }

--- a/robot_controllers_interface/src/controller_loader.cpp
+++ b/robot_controllers_interface/src/controller_loader.cpp
@@ -51,7 +51,8 @@ bool ControllerLoader::init(const std::string& name, ControllerManager* manager)
     {
       controller_ = plugin_loader_.createInstance(controller_type);
       controller_->init(nh, manager);
-    }catch( pluginlib::LibraryLoadException e)
+    }
+    catch( pluginlib::LibraryLoadException e)
     {
       return false;
     }  

--- a/robot_controllers_interface/src/controller_loader.cpp
+++ b/robot_controllers_interface/src/controller_loader.cpp
@@ -52,7 +52,7 @@ bool ControllerLoader::init(const std::string& name, ControllerManager* manager)
       controller_ = plugin_loader_.createInstance(controller_type);
       controller_->init(nh, manager);
     }
-    catch( pluginlib::LibraryLoadException e)
+    catch(pluginlib::LibraryLoadException e)
     {
       return false;
     }  

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -254,7 +254,7 @@ void ControllerManager::execute(const robot_controllers_msgs::QueryControllerSta
     robot_controllers_msgs::ControllerState state = goal->updates[i];
 
     // Make sure controller exists
-    bool in_default_controllers = false;
+    bool in_controller_list = false;
     for (ControllerList::iterator c = controllers_.begin(); c != controllers_.end(); c++)
     {
       if ((*c)->getController()->getName() == state.name)
@@ -263,7 +263,7 @@ void ControllerManager::execute(const robot_controllers_msgs::QueryControllerSta
         {
           if (state.type == (*c)->getController()->getType())
           {
-            in_default_controllers = true;
+            in_controller_list = true;
             break;
           }
           else
@@ -275,11 +275,11 @@ void ControllerManager::execute(const robot_controllers_msgs::QueryControllerSta
             return;
           }
         }
-        in_default_controllers = true;
+        in_controller_list = true;
         break;
       }
     }
-    if (!in_default_controllers)
+    if (!in_controller_list)
     {
       // Check if controller exists on parameter server
       ros::NodeHandle nh;

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -254,7 +254,7 @@ void ControllerManager::execute(const robot_controllers_msgs::QueryControllerSta
     robot_controllers_msgs::ControllerState state = goal->updates[i];
 
     // Make sure controller exists
-    bool exists = false;
+    bool in_default_controllers = false;
     for (ControllerList::iterator c = controllers_.begin(); c != controllers_.end(); c++)
     {
       if ((*c)->getController()->getName() == state.name)
@@ -263,7 +263,7 @@ void ControllerManager::execute(const robot_controllers_msgs::QueryControllerSta
         {
           if (state.type == (*c)->getController()->getType())
           {
-            exists = true;
+            in_default_controllers = true;
             break;
           }
           else
@@ -275,17 +275,34 @@ void ControllerManager::execute(const robot_controllers_msgs::QueryControllerSta
             return;
           }
         }
-        exists = true;
+        in_default_controllers = true;
         break;
       }
     }
-    if (!exists)
+    if (!in_default_controllers)
     {
-      std::stringstream ss;
-      ss << "No such controller to update: " << state.name;
-      getState(result);
-      server_->setAborted(result, ss.str());
-      return;
+      // Check if controller exists on parameter server
+      ros::NodeHandle nh;
+      if (nh.hasParam(state.name))
+      { 
+        // Create controller (in a loader)
+        if (!load(static_cast<std::string>(state.name)))
+        {
+          std::stringstream ss;
+          ss << "Failed to load controller: " << state.name;
+          getState(result);
+          server_->setAborted(result, ss.str());
+          return;
+        }
+      }
+      else
+      {
+        std::stringstream ss;
+        ss << "No such controller to update: " << state.name;
+        getState(result);
+        server_->setAborted(result, ss.str());
+        return;
+      }
     }
 
     // Update state


### PR DESCRIPTION
When a requested controller is not in the list of default controllers, the controller manager will check for the controller on the parameter server. The controller loader now also catches pluginlib exceptions from trying to load a bad controller instead of crashing the controller manager. 

![trying_to_load_bad_controller](https://cloud.githubusercontent.com/assets/1470402/16278661/9e1252f2-386c-11e6-80a2-8940d0076d96.png)
