### PR TITLE
[GCC][Warnings] SYSTEM includes and catch ref

### DIFF
--- a/robot_controllers/CMakeLists.txt
+++ b/robot_controllers/CMakeLists.txt
@@ -53,9 +53,9 @@ catkin_package(
 
 include_directories(
   include
-  ${Boost_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
-  ${orocos_kdl_INCLUDE_DIRS}
+  SYSTEM ${Boost_INCLUDE_DIRS}
+  SYSTEM ${catkin_INCLUDE_DIRS}
+  SYSTEM ${orocos_kdl_INCLUDE_DIRS}
 )
 
 # this is a hack, will eventually be unneeded once orocos-kdl is fixed

--- a/robot_controllers_interface/src/controller_loader.cpp
+++ b/robot_controllers_interface/src/controller_loader.cpp
@@ -52,7 +52,7 @@ bool ControllerLoader::init(const std::string& name, ControllerManager* manager)
       controller_ = plugin_loader_.createInstance(controller_type);
       controller_->init(nh, manager);
     }
-    catch (pluginlib::LibraryLoadException e)
+    catch (pluginlib::LibraryLoadException& e)
     {
       ROS_ERROR_STREAM("Plugin error while loading controller: " << e.what());
       return false;


### PR DESCRIPTION
This is an attempt to fix (silence) the buildbot failures from -Werror

@rctoris I didn't see the build error which the build farm complains about locally- but this would ignore warnings from system headers which we depend on.