### PR TITLE
Add time_from_start information to feedback topic

### DIFF
--- a/robot_controllers/include/robot_controllers/follow_joint_trajectory.h
+++ b/robot_controllers/include/robot_controllers/follow_joint_trajectory.h
@@ -163,6 +163,7 @@ private:
   double goal_time_tolerance_;
 
   control_msgs::FollowJointTrajectoryFeedback feedback_;
+  ros::Time goal_time;
 };
 
 }  // namespace robot_controllers

--- a/robot_controllers/src/follow_joint_trajectory.cpp
+++ b/robot_controllers/src/follow_joint_trajectory.cpp
@@ -121,7 +121,7 @@ int FollowJointTrajectoryController::init(ros::NodeHandle& nh, ControllerManager
   path_tolerance_.qdd.resize(joints_.size());
   goal_tolerance_.q.resize(joints_.size());
   goal_tolerance_.qd.resize(joints_.size());
-  goal_tolerance_.qdd.resize(joints_.size()); 
+  goal_tolerance_.qdd.resize(joints_.size());
 
   // Setup ROS interfaces
   server_.reset(new server_t(nh, "",

--- a/robot_controllers/src/follow_joint_trajectory.cpp
+++ b/robot_controllers/src/follow_joint_trajectory.cpp
@@ -368,6 +368,7 @@ void FollowJointTrajectoryController::executeCb(const control_msgs::FollowJointT
 
   Trajectory new_trajectory;
   Trajectory executable_trajectory;
+  goal_time = goal->trajectory.header.stamp;
 
   // Make a trajectory from our message
   if (!trajectoryFromMsg(goal->trajectory, joint_names_, &new_trajectory))
@@ -547,6 +548,9 @@ void FollowJointTrajectoryController::executeCb(const control_msgs::FollowJointT
 
     // Publish feedback
     feedback_.header.stamp = ros::Time::now();
+    feedback_.desired.time_from_start = feedback_.header.stamp - goal_time;
+    feedback_.actual.time_from_start = feedback_.header.stamp - goal_time;
+    feedback_.error.time_from_start = feedback_.header.stamp - goal_time;
     server_->publishFeedback(feedback_);
     ros::Duration(1/50.0).sleep();
   }


### PR DESCRIPTION
When I used fetch with `follow joint trajectory`, I found `/*_controller/follow_joint_trajectory/feedback` topic do not have `time_from_start` information, so I added `time_from_start` to this topic.

CC @pazeshun, @k-okada