### PR TITLE
Port of: Added gyro interface to robot controllers

### DIFF
--- a/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
@@ -48,11 +48,11 @@ namespace robot_controllers
 /** @brief Base class for a controller manager. */
 class ControllerManager
 {
-  typedef actionlib::SimpleActionServer<robot_controllers_msgs::QueryControllerStatesAction> server_t;
+  using ServerT = actionlib::SimpleActionServer<robot_controllers_msgs::QueryControllerStatesAction>;
 
-  typedef std::vector<ControllerLoaderPtr> ControllerList;
-  typedef std::vector<JointHandlePtr> JointHandleList;
-  typedef std::vector<GyroHandlePtr> GyroHandleList;
+  using ControllerList = std::vector<ControllerLoaderPtr>;
+  using JointHandleList = std::vector<JointHandlePtr> ;
+  using GyroHandleList = std::vector<GyroHandlePtr>;
 
 public:
   ControllerManager();
@@ -84,10 +84,10 @@ public:
   virtual void reset();
 
   /** @brief Add a joint handle. */
-  bool addJointHandle(JointHandlePtr& jointHandlePtr);
+  bool addJointHandle(JointHandlePtr& joint_handle_ptr);
 
   /** @brief Add a gyro handle. */
-  bool addGyroHandle(GyroHandlePtr gyroHandlePtr);
+  bool addGyroHandle(GyroHandlePtr gyro_hanle_ptr);
 
   /**
    * @brief Get the handle associated with a particular joint/controller name.
@@ -125,7 +125,7 @@ private:
   JointHandleList joints_;
   GyroHandleList gyros_;
 
-  boost::shared_ptr<server_t> server_;
+  boost::shared_ptr<ServerT> server_;
 };
 
 }  // namespace robot_controllers

--- a/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
@@ -38,6 +38,7 @@
 #include <robot_controllers_msgs/QueryControllerStatesAction.h>
 
 #include <robot_controllers_interface/joint_handle.h>
+#include <robot_controllers_interface/gyro_handle.h>
 #include <robot_controllers_interface/controller.h>
 #include <robot_controllers_interface/controller_loader.h>
 
@@ -51,6 +52,7 @@ class ControllerManager
 
   typedef std::vector<ControllerLoaderPtr> ControllerList;
   typedef std::vector<JointHandlePtr> JointHandleList;
+  typedef std::vector<GyroHandlePtr> GyroHandleList;
 
 public:
   ControllerManager();
@@ -82,7 +84,10 @@ public:
   virtual void reset();
 
   /** @brief Add a joint handle. */
-  bool addJointHandle(JointHandlePtr& j);
+  bool addJointHandle(JointHandlePtr& jointHandlePtr);
+
+  /** @brief Add a gyro handle. */
+  bool addGyroHandle(GyroHandlePtr gyroHandlePtr);
 
   /**
    * @brief Get the handle associated with a particular joint/controller name.
@@ -98,6 +103,14 @@ public:
    */
   JointHandlePtr getJointHandle(const std::string& name);
 
+  /**
+   * @brief Get the gyro handle associated with a particular gyro name.
+   * @param name The name of the gyro.
+   *
+   * This is mainly a convienence function.
+   */
+  GyroHandlePtr getGyroHandle(const std::string& name);
+
 private:
   /** @brief Action callback. */
   void execute(const robot_controllers_msgs::QueryControllerStatesGoalConstPtr& goal);
@@ -110,6 +123,7 @@ private:
 
   ControllerList controllers_;
   JointHandleList joints_;
+  GyroHandleList gyros_;
 
   boost::shared_ptr<server_t> server_;
 };

--- a/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, Fetch Robotics Inc.
+ * Copyright (c) 2014-2020, Fetch Robotics Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
@@ -63,7 +63,7 @@ public:
   virtual std::string getName() = 0;
 
   /** @brief Get if the data from the Gyro is currently valid. */
-  virtual bool isGyroDataCurrentlyValid() = 0;
+  virtual bool isValid() = 0;
 
 private:
 

--- a/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
@@ -26,11 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-
 // Author: Vincenzo Barbato
-
-
 
 #ifndef ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H
 #define ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H
@@ -38,22 +34,16 @@
 #include <robot_controllers_interface/handle.h>
 #include <geometry_msgs/Vector3.h>
 
-
-
 namespace robot_controllers
 {
-
-
 
 /**
  * @brief Base class for a gyro handle used to provide controller 
  *        direct access to gyro data though controller interface.
  */
-
 class GyroHandle : public Handle
 {
 public:
-
   GyroHandle()
   {
   }
@@ -66,15 +56,6 @@ public:
   /** @brief Get the angular velocities from the gyro */
   virtual const geometry_msgs::Vector3& getAngularVelocities()const = 0;
 
-  /** @brief Set the angular velocities of the gyro */
-  virtual void setAngularVelocities(const geometry_msgs::Vector3& angularVelocities, bool isGyroDataCurrentlyValid) = 0;
-
-  /** @brief Set the name of the gyro */
-  virtual void setName(const std::string& name) = 0;
-
-  /** @brief Set the type of the gyro */
-  virtual void setType(const std::string& type) = 0;
-
   /** @brief Get the type of this gyro */
   virtual const std::string& getType()const = 0;
 
@@ -85,18 +66,7 @@ public:
   virtual std::string getName() = 0;
 
   /** @brief Get the name of this joint. */
-  virtual bool isGyroDataCurrentlyValid()const = 0;
-
-
-
-protected:
-  
-  bool isGyroDataCurrentlyValid_;
-  std::string type_;
-  std::string name_;
-  geometry_msgs::Vector3 angularVelocities_;
-
-
+  virtual bool isGyroDataCurrentlyValid() const = 0;
 
 private:
 
@@ -105,14 +75,8 @@ private:
   GyroHandle& operator=(const GyroHandle&);
 };
 
-
-
 using GyroHandlePtr = boost::shared_ptr<GyroHandle>;
 
-
-
 }  // namespace robot_controllers
-
-
 
 #endif  // ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H

--- a/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
@@ -26,7 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Author: Vincenzo Barbato
+// Author: Vincenzo Barbato, Carl Saldanha
 
 #ifndef ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H
 #define ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H
@@ -54,19 +54,16 @@ public:
   }
 
   /** @brief Get the angular velocities from the gyro */
-  virtual const geometry_msgs::Vector3& getAngularVelocities()const = 0;
+  virtual geometry_msgs::Vector3 getAngularVelocities() = 0;
 
   /** @brief Get the type of this gyro */
-  virtual const std::string& getType()const = 0;
-
-  /** @brief Get the name of this gyro */
-  virtual const std::string& getName()const = 0;
+  virtual std::string getType() = 0;
 
   /** @brief Get the name of this gyro */
   virtual std::string getName() = 0;
 
-  /** @brief Get the name of this joint. */
-  virtual bool isGyroDataCurrentlyValid() const = 0;
+  /** @brief Get if the data from the Gyro is currently valid. */
+  virtual bool isGyroDataCurrentlyValid() = 0;
 
 private:
 

--- a/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
@@ -32,7 +32,6 @@
 #define ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H
 
 #include <robot_controllers_interface/handle.h>
-#include <geometry_msgs/Vector3.h>
 
 namespace robot_controllers
 {
@@ -53,9 +52,6 @@ public:
   {
   }
 
-  /** @brief Get the angular velocities from the gyro */
-  virtual geometry_msgs::Vector3 getAngularVelocities() = 0;
-
   /** @brief Get the type of this gyro */
   virtual std::string getType() = 0;
 
@@ -64,6 +60,15 @@ public:
 
   /** @brief Get if the data from the Gyro is currently valid. */
   virtual bool isValid() = 0;
+
+  /** @brief Get the angular velocity in X direction */
+  virtual double getAngularVelocityX() = 0;
+
+  /** @brief Get the angular velocity in Y direction */
+  virtual double getAngularVelocityY() = 0;
+
+  /** @brief Get the angular velocity in Z direction */
+  virtual double getAngularVelocityZ() = 0;
 
 private:
 

--- a/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/gyro_handle.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Fetch Robotics Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Fetch Robotics Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL FETCH ROBOTICS INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+
+// Author: Vincenzo Barbato
+
+
+
+#ifndef ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H
+#define ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H
+
+#include <robot_controllers_interface/handle.h>
+#include <geometry_msgs/Vector3.h>
+
+
+
+namespace robot_controllers
+{
+
+
+
+/**
+ * @brief Base class for a gyro handle used to provide controller 
+ *        direct access to gyro data though controller interface.
+ */
+
+class GyroHandle : public Handle
+{
+public:
+
+  GyroHandle()
+  {
+  }
+
+  /** @brief Ensure proper cleanup with virtual destructor. */
+  virtual ~GyroHandle()
+  {
+  }
+
+  /** @brief Get the angular velocities from the gyro */
+  virtual const geometry_msgs::Vector3& getAngularVelocities()const = 0;
+
+  /** @brief Set the angular velocities of the gyro */
+  virtual void setAngularVelocities(const geometry_msgs::Vector3& angularVelocities, bool isGyroDataCurrentlyValid) = 0;
+
+  /** @brief Set the name of the gyro */
+  virtual void setName(const std::string& name) = 0;
+
+  /** @brief Set the type of the gyro */
+  virtual void setType(const std::string& type) = 0;
+
+  /** @brief Get the type of this gyro */
+  virtual const std::string& getType()const = 0;
+
+  /** @brief Get the name of this gyro */
+  virtual const std::string& getName()const = 0;
+
+  /** @brief Get the name of this gyro */
+  virtual std::string getName() = 0;
+
+  /** @brief Get the name of this joint. */
+  virtual bool isGyroDataCurrentlyValid()const = 0;
+
+
+
+protected:
+  
+  bool isGyroDataCurrentlyValid_;
+  std::string type_;
+  std::string name_;
+  geometry_msgs::Vector3 angularVelocities_;
+
+
+
+private:
+
+  // No copy
+  GyroHandle(const GyroHandle&);
+  GyroHandle& operator=(const GyroHandle&);
+};
+
+
+
+using GyroHandlePtr = boost::shared_ptr<GyroHandle>;
+
+
+
+}  // namespace robot_controllers
+
+
+
+#endif  // ROBOT_CONTROLLERS_INTERFACE_GYRO_HANDLE_H

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -210,7 +210,7 @@ bool ControllerManager::addJointHandle(JointHandlePtr& joint_handle_ptr)
 
   for (const auto& joint_handle: joints_)
   {
-    if(joint_handle->getName() == joint_handle_ptr->getName())
+    if (joint_handle->getName() == joint_handle_ptr->getName())
     return false;
   }
   
@@ -225,7 +225,7 @@ bool ControllerManager::addGyroHandle(GyroHandlePtr gyro_handle_ptr)
 
   for (const auto& gyro_handle: gyros_)
   {
-    if(gyro_handle->getName() == gyro_handle_ptr->getName())
+    if (gyro_handle->getName() == gyro_handle_ptr->getName())
     return false;
   }
 
@@ -247,7 +247,7 @@ HandlePtr ControllerManager::getHandle(const std::string& name)
   // Then gyros
   for (auto& gyro_handle_pointer: gyros_)
   {
-    if(gyro_handle_pointer and gyro_handle_pointer->getName() == name)
+    if (gyro_handle_pointer and gyro_handle_pointer->getName() == name)
     {
       return gyro_handle_pointer;
     }
@@ -283,11 +283,11 @@ JointHandlePtr ControllerManager::getJointHandle(const std::string& name)
 
 GyroHandlePtr ControllerManager::getGyroHandle(const std::string& name)
 {
-  for(auto& gyro_handle_pointer : gyros_)
+  for (auto& gyro_handle_pointer : gyros_)
   {
-    if(gyro_handle_pointer)
+    if (gyro_handle_pointer)
     {
-      if(gyro_handle_pointer->getName() == name)
+      if (gyro_handle_pointer->getName() == name)
         return gyro_handle_pointer;
     }
   }

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -206,8 +206,11 @@ void ControllerManager::reset()
 bool ControllerManager::addJointHandle(JointHandlePtr& joint_handle_ptr)
 {
   // If we don't already have a handle with
-  // a duplicate name, we add it
-
+  // a duplicate name, and it is not null we add it
+  if (!joint_handle_ptr)
+  {
+    return false;
+  }
   for (const auto& joint_handle: joints_)
   {
     if (joint_handle->getName() == joint_handle_ptr->getName())
@@ -221,8 +224,11 @@ bool ControllerManager::addJointHandle(JointHandlePtr& joint_handle_ptr)
 bool ControllerManager::addGyroHandle(GyroHandlePtr gyro_handle_ptr)
 {
   // If we don't already have a handle with
-  // a duplicate name, we add it
-
+  // a duplicate name, and it is not null we add it
+  if (!gyro_handle_ptr)
+  {
+    return false;
+  }
   for (const auto& gyro_handle: gyros_)
   {
     if (gyro_handle->getName() == gyro_handle_ptr->getName())
@@ -236,27 +242,27 @@ bool ControllerManager::addGyroHandle(GyroHandlePtr gyro_handle_ptr)
 HandlePtr ControllerManager::getHandle(const std::string& name)
 {
   // Try joints first
-  for (auto& j: joints_)
+  for (const auto& j: joints_)
   {
-    if (j and j->getName() == name)
+    if (j->getName() == name)
     {
       return j;
     }
   }
 
   // Then gyros
-  for (auto& gyro_handle_pointer: gyros_)
+  for (const auto& gyro_handle_pointer: gyros_)
   {
-    if (gyro_handle_pointer and gyro_handle_pointer->getName() == name)
+    if (gyro_handle_pointer->getName() == name)
     {
       return gyro_handle_pointer;
     }
   }
 
   // Then controllers
-  for (auto& controller: controllers_)
+  for (const auto& controller: controllers_)
   {
-    if (controller and controller->getController()->getName() == name)
+    if (controller->getController()->getName() == name)
     {
       return controller->getController();
     }
@@ -269,9 +275,9 @@ HandlePtr ControllerManager::getHandle(const std::string& name)
 JointHandlePtr ControllerManager::getJointHandle(const std::string& name)
 {
   // Try joints first
-  for (auto& j: joints_)
+  for (const auto& j: joints_)
   {
-    if (j and j->getName() == name)
+    if (j->getName() == name)
     {
       return j;
     }
@@ -283,12 +289,11 @@ JointHandlePtr ControllerManager::getJointHandle(const std::string& name)
 
 GyroHandlePtr ControllerManager::getGyroHandle(const std::string& name)
 {
-  for (auto& gyro_handle_pointer : gyros_)
+  for (const auto& gyro_handle_pointer : gyros_)
   {
-    if (gyro_handle_pointer)
+    if (gyro_handle_pointer->getName() == name)
     {
-      if (gyro_handle_pointer->getName() == name)
-        return gyro_handle_pointer;
+      return gyro_handle_pointer;
     }
   }
 
@@ -308,7 +313,7 @@ void ControllerManager::execute(const robot_controllers_msgs::QueryControllerSta
 
     // Make sure controller exists
     bool in_controller_list = false;
-    for (auto& c: controllers_)
+    for (const auto& c: controllers_)
     {
       if (c->getController()->getName() == state.name)
       {

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -74,7 +74,7 @@ int ControllerManager::init(ros::NodeHandle& nh)
   }
 
   // Setup actionlib server
-  server_.reset(new server_t(nh, "/query_controller_states",
+  server_.reset(new ServerT(nh, "/query_controller_states",
                              boost::bind(&ControllerManager::execute, this, _1),
                              false));
   server_->start();

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -203,10 +203,33 @@ void ControllerManager::reset()
   }
 }
 
-bool ControllerManager::addJointHandle(JointHandlePtr& j)
+bool ControllerManager::addJointHandle(JointHandlePtr& jointHandlePtr)
 {
-  // TODO: check for duplicate names?
-  joints_.push_back(j);
+  // If we don't already have a handle with
+  // a duplicate name, we add it
+
+  for(auto jointHandlePointer : joints_)
+  {
+    if(jointHandlePointer->getName() == jointHandlePtr->getName())
+    return false;
+  }
+  
+  joints_.push_back(jointHandlePtr);
+  return true;
+}
+
+bool ControllerManager::addGyroHandle(GyroHandlePtr gyroHandlePtr)
+{
+  // If we don't already have a handle with
+  // a duplicate name, we add it
+
+  for(auto gyroHandlePointer : gyros_)
+  {
+    if(gyroHandlePointer->getName() == gyroHandlePtr->getName())
+    return false;
+  }
+
+  gyros_.push_back(gyroHandlePtr);
   return true;
 }
 
@@ -217,6 +240,16 @@ HandlePtr ControllerManager::getHandle(const std::string& name)
   {
     if ((*j)->getName() == name)
       return *j;
+  }
+
+  // Then gyros
+  for(auto& gyroHandlePointer : gyros_)
+  {
+    if(gyroHandlePointer)
+    {
+      if(gyroHandlePointer->getName() == name)
+        return gyroHandlePointer;
+    }
   }
 
   // Then controllers
@@ -241,6 +274,21 @@ JointHandlePtr ControllerManager::getJointHandle(const std::string& name)
 
   // Not found
   return JointHandlePtr();
+}
+
+GyroHandlePtr ControllerManager::getGyroHandle(const std::string& name)
+{
+  for(auto gyroHandlePointer : gyros_)
+  {
+    if(gyroHandlePointer)
+    {
+      if(gyroHandlePointer->getName() == name)
+        return gyroHandlePointer;
+    }
+  }
+
+  // Not found
+  return GyroHandlePtr();
 }
 
 void ControllerManager::execute(const robot_controllers_msgs::QueryControllerStatesGoalConstPtr& goal)

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -203,73 +203,78 @@ void ControllerManager::reset()
   }
 }
 
-bool ControllerManager::addJointHandle(JointHandlePtr& jointHandlePtr)
+bool ControllerManager::addJointHandle(JointHandlePtr& joint_handle_ptr)
 {
   // If we don't already have a handle with
   // a duplicate name, we add it
 
-  for(auto jointHandlePointer : joints_)
+  for (const auto& joint_handle: joints_)
   {
-    if(jointHandlePointer->getName() == jointHandlePtr->getName())
+    if(joint_handle->getName() == joint_handle_ptr->getName())
     return false;
   }
   
-  joints_.push_back(jointHandlePtr);
+  joints_.push_back(joint_handle_ptr);
   return true;
 }
 
-bool ControllerManager::addGyroHandle(GyroHandlePtr gyroHandlePtr)
+bool ControllerManager::addGyroHandle(GyroHandlePtr gyro_handle_ptr)
 {
   // If we don't already have a handle with
   // a duplicate name, we add it
 
-  for(auto gyroHandlePointer : gyros_)
+  for (const auto& gyro_handle: gyros_)
   {
-    if(gyroHandlePointer->getName() == gyroHandlePtr->getName())
+    if(gyro_handle->getName() == gyro_handle_ptr->getName())
     return false;
   }
 
-  gyros_.push_back(gyroHandlePtr);
+  gyros_.push_back(gyro_handle_ptr);
   return true;
 }
 
 HandlePtr ControllerManager::getHandle(const std::string& name)
 {
   // Try joints first
-  for (JointHandleList::iterator j = joints_.begin(); j != joints_.end(); j++)
+  for (auto j: joints_)
   {
-    if ((*j)->getName() == name)
-      return *j;
+    if (j and j->getName() == name)
+    {
+      return j;
+    }
   }
 
   // Then gyros
-  for(auto& gyroHandlePointer : gyros_)
+  for (auto gyro_handle_pointer: gyros_)
   {
-    if(gyroHandlePointer)
+    if(gyro_handle_pointer and gyro_handle_pointer->getName() == name)
     {
-      if(gyroHandlePointer->getName() == name)
-        return gyroHandlePointer;
+      return gyro_handle_pointer;
     }
   }
 
   // Then controllers
-  for (ControllerList::iterator c = controllers_.begin(); c != controllers_.end(); c++)
+  for (auto controller: controllers_)
   {
-    if ((*c)->getController()->getName() == name)
-      return (*c)->getController();
+    if (controller and controller->getController()->getName() == name)
+    {
+      return controller->getController();
+    }
   }
 
   // Not found
-  return HandlePtr();
+  return HandlePtr{};
 }
 
 JointHandlePtr ControllerManager::getJointHandle(const std::string& name)
 {
   // Try joints first
-  for (JointHandleList::iterator j = joints_.begin(); j != joints_.end(); j++)
+  for (auto j: joints_)
   {
-    if ((*j)->getName() == name)
-      return *j;
+    if (j and j->getName() == name)
+    {
+      return j;
+    }
   }
 
   // Not found
@@ -278,12 +283,12 @@ JointHandlePtr ControllerManager::getJointHandle(const std::string& name)
 
 GyroHandlePtr ControllerManager::getGyroHandle(const std::string& name)
 {
-  for(auto gyroHandlePointer : gyros_)
+  for(auto gyro_handle_pointer : gyros_)
   {
-    if(gyroHandlePointer)
+    if(gyro_handle_pointer)
     {
-      if(gyroHandlePointer->getName() == name)
-        return gyroHandlePointer;
+      if(gyro_handle_pointer->getName() == name)
+        return gyro_handle_pointer;
     }
   }
 


### PR DESCRIPTION
This is a port of this PR https://github.com/fetchrobotics/robot_controllers/pull/42 with the requested changes

From that PR


## Description
Need to provide controller direct access to gyro data though controller interface.

## Reason
The gyro will be used to stabilize the wheel controller in situations when wheels start slipping or when wheels have to go over bumps

## Tests
Code compiles but will need to be tested

@mikeferguson FYI since you commented on prior PR