### PR TITLE
build fixes for noetic

### DIFF
--- a/robot_controllers/CMakeLists.txt
+++ b/robot_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(robot_controllers)
 
 if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
@@ -57,9 +57,6 @@ include_directories(
   SYSTEM ${catkin_INCLUDE_DIRS}
   SYSTEM ${orocos_kdl_INCLUDE_DIRS}
 )
-
-# this is a hack, will eventually be unneeded once orocos-kdl is fixed
-link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 add_library(robot_controllers
   src/cartesian_pose.cpp

--- a/robot_controllers/package.xml
+++ b/robot_controllers/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="3">
   <name>robot_controllers</name>
   <version>0.6.0</version>
   <description>
@@ -17,39 +18,24 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>angles</build_depend>
-  <build_depend>actionlib</build_depend>
-  <build_depend>actionlib_msgs</build_depend>
-  <build_depend>control_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>kdl_parser</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>orocos_kdl</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>robot_controllers_interface</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf_conversions</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>urdf</build_depend>
 
-  <run_depend>actionlib</run_depend>
-  <run_depend>actionlib_msgs</run_depend>
-  <run_depend>control_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>kdl_parser</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>orocos_kdl</run_depend>
-  <run_depend>robot_controllers_interface</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>tf_conversions</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>urdf</run_depend>
+  <depend>actionlib</depend>
+  <depend>actionlib_msgs</depend>
+  <depend>control_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>kdl_parser</depend>
+  <depend>nav_msgs</depend>
+  <depend condition="$ROS_DISTRO != noetic">orocos_kdl</depend>
+  <depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</depend>
+  <depend>pluginlib</depend>
+  <depend>robot_controllers_interface</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf</depend>
+  <depend>tf_conversions</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>urdf</depend>
 
   <export>
     <robot_controllers plugin="${prefix}/robot_controllers.xml"/>


### PR DESCRIPTION
This should support both melodic and noetic on same branch:
 * orocos_kdl is now a system dependency so the rosdep key has changed.
 * package format 3 is required to handle conditional on rosdistro
 * old build hackery is no longer needed.
 * cmake minimum version is updated per migration guide (http://wiki.ros.org/noetic/Migration) supports as far back as Kinetic.
