### PR TITLE
test, fix and improve scaled_mimic

### DIFF
--- a/robot_controllers/CMakeLists.txt
+++ b/robot_controllers/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(robot_controllers SHARED
   src/pid.cpp
   src/point_head.cpp
   src/scaled_mimic.cpp
+  src/mimic_joint_handle.cpp
 )
 target_link_libraries(robot_controllers
   ${orocos_kdl_LIBRARIES}

--- a/robot_controllers/include/robot_controllers/mimic_joint_handle.h
+++ b/robot_controllers/include/robot_controllers/mimic_joint_handle.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, Michael Ferguson
+ * Copyright (c) 2014-2015, Fetch Robotics Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Fetch Robotics Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL FETCH ROBOTICS INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Author: Michael Ferguson
+
+#ifndef ROBOT_CONTROLLERS__MIMIC_JOINT_HANDLE_H_
+#define ROBOT_CONTROLLERS__MIMIC_JOINT_HANDLE_H_
+
+#include <memory>
+#include <string>
+
+#include "robot_controllers_interface/joint_handle.h"
+
+namespace robot_controllers
+{
+
+/**
+ * @brief Joint handle for scaled mimic controller
+ */
+class MimicJointHandle : public robot_controllers_interface::JointHandle
+{
+public:
+  MimicJointHandle(const std::string& name,
+                   robot_controllers_interface::JointHandlePtr mimic);
+
+  /** @brief Ensure proper cleanup with virtual destructor. */
+  virtual ~MimicJointHandle() = default;
+
+  /**
+   * @brief Set a position command for this joint.
+   * @param position Position command in radians or meters.
+   * @param velocity Velocity command in rad/sec or meters/sec.
+   * @param effort Effort command in Nm or N.
+   */
+  virtual void setPosition(double position, double velocity, double effort);
+
+  /**
+   * @brief Set a velocity command for this joint.
+   * @param velocity Velocity command in rad/sec or meters/sec.
+   * @param effort Effort command in Nm or N.
+   */
+  virtual void setVelocity(double velocity, double effort);
+
+  /**
+   * @brief Set an effort command for this joint.
+   * @param effort Effort command in Nm or N.
+   */
+  virtual void setEffort(double effort);
+
+  /** @brief Get the position of the joint in radians or meters. */
+  virtual double getPosition();
+
+  /** @brief Get the velocity of the joint in rad/sec or meters/sec. */
+  virtual double getVelocity();
+
+  /** @brief Get applied effort of a joint in Nm or N. */
+  virtual double getEffort();
+
+  /** @brief Is this joint continuous (has no position limits). */
+  virtual bool isContinuous();
+
+  /** @brief Get the minimum valid position command. */
+  virtual double getPositionMin();
+
+  /** @brief Get the maximum valid position command. */
+  virtual double getPositionMax();
+
+  /** @brief Get the maximum velocity command. */
+  virtual double getVelocityMax();
+
+  /** @brief Get the maximum effort command. */
+  virtual double getEffortMax();
+
+  /** @brief Get the name of this joint. */
+  virtual std::string getName();
+
+  /** @brief Reset the command. */
+  virtual void reset();
+
+private:
+  double position_, velocity_, effort_;
+  bool continuous_;
+  double min_pos_, max_pos_, max_vel_, max_eff_;
+  std::string name_;
+
+  // No copy
+  MimicJointHandle(const MimicJointHandle&) = delete;
+  MimicJointHandle& operator=(const MimicJointHandle&) = delete;
+};
+
+
+}  // namespace robot_controllers
+
+#endif  // ROBOT_CONTROLLERS__MIMIC_JOINT_HANDLE_H_

--- a/robot_controllers/src/mimic_joint_handle.cpp
+++ b/robot_controllers/src/mimic_joint_handle.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, Michael Ferguson
+ * Copyright (c) 2014-2015, Fetch Robotics Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Fetch Robotics Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL FETCH ROBOTICS INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Author: Michael Ferguson
+
+#include "robot_controllers/mimic_joint_handle.h"
+
+namespace robot_controllers
+{
+
+MimicJointHandle::MimicJointHandle(const std::string & name,
+                                   robot_controllers_interface::JointHandlePtr mimic) :
+  position_(0.0),
+  velocity_(0.0),
+  effort_(0.0),
+  continuous_(mimic->isContinuous()),
+  min_pos_(mimic->getPositionMin()),
+  max_pos_(mimic->getPositionMax()),
+  max_vel_(mimic->getVelocityMax()),
+  max_eff_(mimic->getEffortMax()),
+  name_(name)
+{
+}
+
+void MimicJointHandle::setPosition(double position, double velocity, double effort)
+{
+  // Just copy (mimic controller calls this)
+  position_ = position;
+  velocity_ = velocity;
+  effort_ = effort;
+}
+
+void MimicJointHandle::setVelocity(double velocity, double effort)
+{
+  velocity_ = velocity;
+  effort_ = effort;
+}
+
+void MimicJointHandle::setEffort(double effort)
+{
+  effort_ = effort;
+}
+
+double MimicJointHandle::getPosition()
+{
+  return position_;
+}
+
+double MimicJointHandle::getVelocity()
+{
+  return velocity_;
+}
+
+double MimicJointHandle::getEffort()
+{
+  return effort_;
+}
+
+bool MimicJointHandle::isContinuous()
+{
+  return continuous_;
+}
+
+double MimicJointHandle::getPositionMin()
+{
+  return min_pos_;
+}
+
+double MimicJointHandle::getPositionMax()
+{
+  return max_pos_;
+}
+
+double MimicJointHandle::getVelocityMax()
+{
+  return max_vel_;
+}
+
+double MimicJointHandle::getEffortMax()
+{
+  return max_eff_;
+}
+
+std::string MimicJointHandle::getName()
+{
+  return name_;
+}
+
+void MimicJointHandle::reset()
+{
+  // no-op
+}
+
+}  // namespace robot_controllers

--- a/robot_controllers/src/scaled_mimic.cpp
+++ b/robot_controllers/src/scaled_mimic.cpp
@@ -36,6 +36,7 @@
 
 #include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/scaled_mimic.h>
+#include "robot_controllers/mimic_joint_handle.h"
 
 PLUGINLIB_EXPORT_CLASS(robot_controllers::ScaledMimicController, robot_controllers_interface::Controller)
 
@@ -57,9 +58,23 @@ int ScaledMimicController::init(const std::string& name,
 
   // Setup Joints, Params
   std::string mimic = node->declare_parameter<std::string>(getName() + ".mimic_joint", "torso_lift_joint");
-  std::string controlled = node->declare_parameter<std::string>(getName() + ".mimic_joint", "bellows_joint");
   joint_to_mimic_ = manager->getJointHandle(mimic);
+  if (joint_to_mimic_ == nullptr)
+  {
+    RCLCPP_ERROR(rclcpp::get_logger(getName()), "Could not get %s", mimic.c_str());
+    initialized_ = false;
+    return -1;
+  }
+  std::string controlled = node->declare_parameter<std::string>(getName() + ".controlled_joint", "bellows_joint");
   joint_to_control_ = manager->getJointHandle(controlled);
+  if (joint_to_control_ == nullptr)
+  {
+    RCLCPP_WARN(rclcpp::get_logger(getName()), "Could not get %s, automatically creating it", controlled.c_str());
+    robot_controllers_interface::JointHandlePtr joint =
+      std::make_shared<MimicJointHandle>(controlled, joint_to_mimic_);
+    manager->addJointHandle(joint);
+    joint_to_control_ = joint;
+  }
   scale_ = node->declare_parameter<double>(getName() + ".mimic_scale", 1.0);
 
   initialized_ = true;
@@ -99,7 +114,7 @@ void ScaledMimicController::update(const rclcpp::Time& now, const rclcpp::Durati
   if (!initialized_)
     return;
 
-  joint_to_control_->setPosition(scale_*joint_to_mimic_->getPosition(), 0, 0);
+  joint_to_control_->setPosition(scale_ * joint_to_mimic_->getPosition(), 0, 0);
 }
 
 std::vector<std::string> ScaledMimicController::getCommandedNames()


### PR DESCRIPTION
* fix porting bug in parameter name
* add checks/logging for missing joint handle
* automatically create a mimic joint if not present

In ROS1 you had to manually create the mimic joint,
which would result in the same boilerplate code being
all over the place