### PR TITLE
Switch class_list_macros import from h to hpp

### DIFF
--- a/robot_controllers/src/cartesian_pose.cpp
+++ b/robot_controllers/src/cartesian_pose.cpp
@@ -39,7 +39,7 @@
  * Author: Michael Ferguson, Wim Meeussen
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/cartesian_pose.h>
 
 #include <urdf/model.h>

--- a/robot_controllers/src/cartesian_twist.cpp
+++ b/robot_controllers/src/cartesian_twist.cpp
@@ -39,7 +39,7 @@
  * Author: Michael Ferguson, Wim Meeussen, Hanjun Song
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/cartesian_twist.h>
 
 #include <urdf/model.h>

--- a/robot_controllers/src/cartesian_wrench.cpp
+++ b/robot_controllers/src/cartesian_wrench.cpp
@@ -39,7 +39,7 @@
  * Author: Michael Ferguson, Wim Meeussen
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/cartesian_wrench.h>
 
 #include <urdf/model.h>

--- a/robot_controllers/src/diff_drive_base.cpp
+++ b/robot_controllers/src/diff_drive_base.cpp
@@ -36,7 +36,7 @@
 // Author: Michael Ferguson
 
 #include <angles/angles.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/diff_drive_base.h>
 
 PLUGINLIB_EXPORT_CLASS(robot_controllers::DiffDriveBaseController, robot_controllers::Controller)

--- a/robot_controllers/src/follow_joint_trajectory.cpp
+++ b/robot_controllers/src/follow_joint_trajectory.cpp
@@ -35,7 +35,7 @@
 
 /* Author: Michael Ferguson */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/follow_joint_trajectory.h>
 
 using angles::shortest_angular_distance;

--- a/robot_controllers/src/gravity_compensation.cpp
+++ b/robot_controllers/src/gravity_compensation.cpp
@@ -35,7 +35,7 @@
 
 /* Author: Michael Ferguson */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/gravity_compensation.h>
 
 PLUGINLIB_EXPORT_CLASS(robot_controllers::GravityCompensation, robot_controllers::Controller)

--- a/robot_controllers/src/parallel_gripper.cpp
+++ b/robot_controllers/src/parallel_gripper.cpp
@@ -35,7 +35,7 @@
 
 // Author: Michael Ferguson
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/parallel_gripper.h>
 
 PLUGINLIB_EXPORT_CLASS(robot_controllers::ParallelGripperController, robot_controllers::Controller)

--- a/robot_controllers/src/point_head.cpp
+++ b/robot_controllers/src/point_head.cpp
@@ -35,7 +35,7 @@
 
 // Author: Michael Ferguson
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/point_head.h>
 
 #include <urdf/model.h>

--- a/robot_controllers/src/scaled_mimic.cpp
+++ b/robot_controllers/src/scaled_mimic.cpp
@@ -34,7 +34,7 @@
 
 // Author: Michael Ferguson
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <robot_controllers/scaled_mimic.h>
 
 PLUGINLIB_EXPORT_CLASS(robot_controllers::ScaledMimicController, robot_controllers::Controller)


### PR DESCRIPTION
Found this while trying to import `class_loader` into bazel land. I'm not sure why this hasn't bitten us before. In the official class_loader repository they recommend importing `class_loader.hpp` instead of `class_loader.h`

https://github.com/ros/class_loader/blob/melodic-devel/include/class_loader/class_loader.h#L40

I found that I could not compile with `class_loader.h` and would hit that deprecation notice. However, when we `catkin build` we do not hit that.


