### PR TITLE
move transform listener to manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ as is the case for Fetch and Freight.
    * The action query interface has been converted to a service interface. ROS2 allows asynchronous
      services and so the overhead of an action interface is no longer warranted. See the scripts
      in robot_controllers_interface package for examples of using this interface.
+   * The ControllerManager has a constructor that takes a tf2_ros::Buffer input, when this is
+     used no additional TransformListeners will be create.
  * Controllers:
    * All controllers have migrated to using TF2.
    * The CartesianPose controller now takes a a TwistStamped (previously, it used an unstamped

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ as is the case for Fetch and Freight.
      services and so the overhead of an action interface is no longer warranted. See the scripts
      in robot_controllers_interface package for examples of using this interface.
    * The ControllerManager has a constructor that takes a tf2_ros::Buffer input, when this is
-     used no additional TransformListeners will be create.
+     used, no additional TransformListeners will be created.
  * Controllers:
    * All controllers have migrated to using TF2.
    * The CartesianPose controller now takes a a TwistStamped (previously, it used an unstamped

--- a/robot_controllers/include/robot_controllers/cartesian_pose.h
+++ b/robot_controllers/include/robot_controllers/cartesian_pose.h
@@ -61,7 +61,6 @@
 #include "kdl/frames.hpp"
 
 #include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
 
 namespace robot_controllers
 {
@@ -156,7 +155,6 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr command_sub_;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::vector<robot_controllers_interface::JointHandlePtr> joints_;
   std::vector<robot_controllers::PID> pid_;
 };

--- a/robot_controllers/include/robot_controllers/cartesian_wrench.h
+++ b/robot_controllers/include/robot_controllers/cartesian_wrench.h
@@ -56,9 +56,6 @@
 #include "kdl/chainjnttojacsolver.hpp"
 #include "kdl/frames.hpp"
 
-#include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
-
 namespace robot_controllers
 {
 
@@ -146,8 +143,6 @@ private:
 
   rclcpp::Subscription<geometry_msgs::msg::Wrench>::SharedPtr command_sub_;
 
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::vector<robot_controllers_interface::JointHandlePtr> joints_;
 };
 

--- a/robot_controllers/include/robot_controllers/point_head.h
+++ b/robot_controllers/include/robot_controllers/point_head.h
@@ -50,7 +50,6 @@
 #include "robot_controllers_interface/joint_handle.h"
 #include "robot_controllers_interface/controller_manager.h"
 #include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
 #include "control_msgs/action/point_head.hpp"
 
 #include "robot_controllers/trajectory.h"
@@ -170,7 +169,6 @@ private:
 
   KDL::Tree kdl_tree_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
 }  // namespace robot_controllers

--- a/robot_controllers/src/cartesian_pose.cpp
+++ b/robot_controllers/src/cartesian_pose.cpp
@@ -134,9 +134,8 @@ int CartesianPoseController::init(const std::string& name,
     if (kdl_chain_.getSegment(i).getJoint().getType() != KDL::Joint::None)
       joints_.push_back(manager_->getJointHandle(kdl_chain_.getSegment(i).getJoint().getName()));
 
-  // Setup transform listener
-  tf_buffer_.reset(new tf2_ros::Buffer(node_->get_clock()));
-  tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_));
+  // Setup transform buffer
+  tf_buffer_ = manager_->getTransformBuffer();
 
   // Subscribe to command
   std::string topic_name = get_safe_topic_name(name) + "/command";

--- a/robot_controllers/src/point_head.cpp
+++ b/robot_controllers/src/point_head.cpp
@@ -144,9 +144,8 @@ int PointHeadController::init(const std::string& name,
 #endif
   }
 
-  // Setup transform listener
-  tf_buffer_.reset(new tf2_ros::Buffer(node_->get_clock()));
-  tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_));
+  // Setup transform buffer
+  tf_buffer_ = manager_->getTransformBuffer();
 
   // Start action server
   active_goal_.reset();

--- a/robot_controllers_interface/CMakeLists.txt
+++ b/robot_controllers_interface/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(ament_cmake REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(robot_controllers_msgs REQUIRED)
+find_package(tf2_ros)
 
 include_directories(
   include
@@ -32,6 +33,7 @@ ament_target_dependencies(robot_controllers_interface
   pluginlib
   rclcpp
   robot_controllers_msgs
+  tf2_ros
 )
 target_compile_definitions(robot_controllers_interface PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
@@ -67,5 +69,6 @@ ament_export_dependencies(
   pluginlib
   rclcpp
   robot_controllers_msgs
+  tf2_ros
 )
 ament_package()

--- a/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
+++ b/robot_controllers_interface/include/robot_controllers_interface/controller_manager.h
@@ -42,6 +42,8 @@
 #include "robot_controllers_interface/gyro_handle.h"
 #include "robot_controllers_interface/controller.h"
 #include "robot_controllers_interface/controller_loader.h"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 
 namespace robot_controllers_interface
 {
@@ -67,6 +69,12 @@ public:
    * @returns 0 if success, negative values are error codes.
    *
    * Note: JointHandles should be added before this is called.
+   */
+  virtual int init(std::shared_ptr<rclcpp::Node> node,
+                   std::shared_ptr<tf2_ros::Buffer> buffer);
+
+  /**
+   * @brief Older interface that does not allow for passing in a buffer.
    */
   virtual int init(std::shared_ptr<rclcpp::Node> node);
 
@@ -120,6 +128,12 @@ public:
    */
   std::vector<std::string> getControllerNames();
 
+  /**
+   * @brief In ROS2, each transform listener incurs an extra node, limit this
+   *        reusing the same transform listener where possible.
+   */
+  std::shared_ptr<tf2_ros::Buffer> getTransformBuffer();
+
 private:
   /** @brief Service callback */
   void callback(
@@ -138,6 +152,9 @@ private:
 
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<robot_controllers_msgs::srv::QueryControllerStates>::SharedPtr server_;
+
+  std::shared_ptr<tf2_ros::Buffer> tf2_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
 };
 
 using ControllerManagerPtr = std::shared_ptr<ControllerManager>;

--- a/robot_controllers_interface/package.xml
+++ b/robot_controllers_interface/package.xml
@@ -22,6 +22,7 @@
   <depend>robot_controllers_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_cpplint</test_depend>
 

--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -47,7 +47,19 @@ ControllerManager::ControllerManager()
 
 int ControllerManager::init(std::shared_ptr<rclcpp::Node> node)
 {
+  // Create shared buffer and listener
+  std::shared_ptr<tf2_ros::Buffer> buffer =
+    std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+  tf2_listener_ = std::make_shared<tf2_ros::TransformListener>(*buffer);
+
+  return init(node, buffer);
+}
+
+int ControllerManager::init(std::shared_ptr<rclcpp::Node> node,
+                            std::shared_ptr<tf2_ros::Buffer> buffer)
+{
   node_ = node;
+  tf2_buffer_ = buffer;
 
   // Find and load default controllers
   std::vector<std::string> controller_names =
@@ -317,6 +329,11 @@ std::vector<std::string> ControllerManager::getControllerNames()
     names.push_back((*c)->getController()->getName());
   }
   return names;
+}
+
+std::shared_ptr<tf2_ros::Buffer> ControllerManager::getTransformBuffer()
+{
+  return tf2_buffer_;
 }
 
 void ControllerManager::callback(


### PR DESCRIPTION
each transform listener incurs an extra DDS node, which can
have a significant effect in a large system. this change
allows our robot driverrs to have a single shared transform
listener across all controllers (and even the whole node,
since the buffer can be passed in with the new constructor)