### PR TITLE
fix a bug in the older init function

### DIFF
--- a/robot_controllers_interface/src/controller_manager.cpp
+++ b/robot_controllers_interface/src/controller_manager.cpp
@@ -49,7 +49,7 @@ int ControllerManager::init(std::shared_ptr<rclcpp::Node> node)
 {
   // Create shared buffer and listener
   std::shared_ptr<tf2_ros::Buffer> buffer =
-    std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+    std::make_shared<tf2_ros::Buffer>(node->get_clock());
   tf2_listener_ = std::make_shared<tf2_ros::TransformListener>(*buffer);
 
   return init(node, buffer);


### PR DESCRIPTION
While the new init function works just fine, the old one segfaults since node_ is not yet set.