### PR TITLE
fix cancellation of trajectory action

### DIFF
--- a/robot_controllers/src/follow_joint_trajectory.cpp
+++ b/robot_controllers/src/follow_joint_trajectory.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, Michael Ferguson
+ *  Copyright (c) 2020-2024, Michael Ferguson
  *  Copyright (c) 2014-2015, Fetch Robotics Inc.
  *  Copyright (c) 2013, Unbounded Robotics Inc.
  *  All rights reserved.
@@ -204,6 +204,17 @@ void FollowJointTrajectoryController::update(const rclcpp::Time& now, const rclc
   {
     std::lock_guard<std::mutex> lock(sampler_mutex_);
 
+    // Have we been canceled?
+    if (active_goal_->is_canceling())
+    {
+      RCLCPP_ERROR(rclcpp::get_logger(getName()),
+                   "Trajectory cancelled.");
+      auto result = std::make_shared<FollowJointTrajectoryAction::Result>();
+      active_goal_->canceled(result);
+      active_goal_.reset();
+      return;
+    }
+
     // Interpolate trajectory
     TrajectoryPoint p = sampler_->sample(to_sec(now));
     unwindTrajectoryPoint(continuous_, p);
@@ -387,18 +398,11 @@ rclcpp_action::GoalResponse FollowJointTrajectoryController::handle_goal(
 rclcpp_action::CancelResponse FollowJointTrajectoryController::handle_cancel(
     const std::shared_ptr<FollowJointTrajectoryGoal> goal_handle)
 {
-  // Always accept
   if (active_goal_ && active_goal_->get_goal_id() == goal_handle->get_goal_id())
   {
-    RCLCPP_ERROR(rclcpp::get_logger(getName()),
-                 "Trajectory cancelled.");
-    auto result = std::make_shared<FollowJointTrajectoryAction::Result>();
-    active_goal_->canceled(result);
-    active_goal_.reset();
     return rclcpp_action::CancelResponse::ACCEPT;
   }
-
-  return rclcpp_action::CancelResponse::ACCEPT;
+  return rclcpp_action::CancelResponse::REJECT;
 }
 
 void FollowJointTrajectoryController::handle_accepted(


### PR DESCRIPTION
Without this, canceling a trajectory (say, using the 'stop' button in MoveIt) results in an error:

```
[gdb-1] [INFO] [1733514002.130626439] Started arm_controller.follow_joint_trajectory
[gdb-1] [ERROR] [1733514002.891465664] [arm_controller.follow_joint_trajectory]: Trajectory cancelled.
[gdb-1] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
[gdb-1]   what():  goal_handle attempted invalid transition from state EXECUTING with event CANCELED, at ./src/rcl_action/goal_handle.c:95
[gdb-1] 
```